### PR TITLE
Wire AI-WOC send route and env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+RESEND_API_KEY=
+AI_WOC_FROM_EMAIL=
+AI_WOC_DEFAULT_TO_EMAIL=Christophertroyhilton@gmail.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+dist
+.env
+.env.local
+.env.*.local
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,3 +13,80 @@ Hard rule: generate a draft first, require confirmation, then enable send.
 MVP stack: Next.js, TypeScript, local state, server-side email route.
 
 Boundaries: AI-WOC is not AI-CIS. Do not create Lean Incident Reports, ROI reports, or case studies.
+
+## Local setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Create a local environment file:
+
+```bash
+cp .env.example .env.local
+```
+
+Fill in the local values in `.env.local`.
+
+Do not commit `.env.local` or any real API keys.
+
+## Environment variables
+
+```env
+RESEND_API_KEY=
+AI_WOC_FROM_EMAIL=
+AI_WOC_DEFAULT_TO_EMAIL=Christophertroyhilton@gmail.com
+```
+
+`RESEND_API_KEY` is used only by the server-side send route.
+
+`AI_WOC_FROM_EMAIL` must be a sender address approved by the email provider.
+
+`AI_WOC_DEFAULT_TO_EMAIL` is the default Engineering correction request recipient.
+
+## Run the app
+
+```bash
+npm run dev
+```
+
+Build check:
+
+```bash
+npm run build
+```
+
+## Confirmation-before-send workflow
+
+AI-WOC must not send automatically.
+
+The app generates two outputs first:
+
+1. Engineering Work Order Correction Report
+2. Engineering email draft
+
+The Send Email button remains disabled until the user confirms:
+
+- Work order number is correct
+- Part number is correct
+- Operation/process is correct
+- Issue and requested correction are accurate
+- Email draft is ready to send
+
+## API route
+
+`POST /api/send`
+
+Expected JSON body:
+
+```json
+{
+  "subject": "Work Order Correction Request",
+  "emailBody": "Email draft body",
+  "reportBody": "Engineering Work Order Correction Report"
+}
+```
+
+The route appends the report below the email draft and sends the message using Resend from the server side.

--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -1,18 +1,40 @@
 import { NextResponse } from 'next/server';
+import { Resend } from 'resend';
 
 export async function POST(req: Request) {
   try {
     const { subject, emailBody, reportBody } = await req.json();
 
     if (!subject || !emailBody || !reportBody) {
-      return NextResponse.json({ error: 'subject, emailBody, and reportBody are required.' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'subject, emailBody, and reportBody are required.' },
+        { status: 400 }
+      );
     }
 
-    return NextResponse.json({
-      success: false,
-      error: 'Email provider is not configured yet. The draft and report were generated successfully.',
-    }, { status: 501 });
+    const apiKey = process.env.RESEND_API_KEY;
+    const from = process.env.AI_WOC_FROM_EMAIL;
+    const to = process.env.AI_WOC_DEFAULT_TO_EMAIL;
+
+    if (!apiKey || !from || !to) {
+      return NextResponse.json(
+        { error: 'Server email configuration is missing.' },
+        { status: 500 }
+      );
+    }
+
+    const resend = new Resend(apiKey);
+    const fullBody = `${emailBody}\n\n--------------------\nENGINEERING WORK ORDER CORRECTION REPORT\n--------------------\n\n${reportBody}`;
+
+    const sent = await resend.emails.send({
+      from,
+      to,
+      subject,
+      text: fullBody,
+    });
+
+    return NextResponse.json({ success: true, id: sent.data?.id ?? null });
   } catch {
-    return NextResponse.json({ error: 'Failed to process send request.' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to send email.' }, { status: 500 });
   }
 }


### PR DESCRIPTION
### Motivation

- Finish the AI-WOC Lite MVP setup after PR #1.
- Add environment setup files and wire the server-side send route to Resend.
- Keep the work isolated to the standalone AI-WOC repository.

### Description

- Adds `.env.example` with required email environment variables.
- Adds `.gitignore` for Node, Next, and local environment files.
- Replaces the placeholder send route with a server-side Resend implementation.
- Updates README with local setup, environment variables, run/build commands, confirmation-before-send workflow, and API contract.

### Notes

- No secrets are committed.
- The send route reads configuration only from server-side environment variables.
- Codex was still mounted to the wrong workspace, so this PR was created directly in GitHub.

### Testing

- Not run in this environment.
