### PR TITLE
Upgrade Next.js security patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.3.1",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "next": "15.3.8",
+    "react": "19.1.2",
+    "react-dom": "19.1.2",
     "resend": "^4.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation

Vercel blocked the deployment because the project was using Next.js 15.3.1, which is flagged as vulnerable.

### Description

- Upgrades `next` from `15.3.1` to `15.3.8`.
- Upgrades `react` and `react-dom` from `19.1.0` to `19.1.2`.

### Notes

- Next.js security guidance lists patched versions for affected 15.x release lines.
- This change should allow Vercel to redeploy without the vulnerable Next.js warning blocking the deployment.

### Testing

- Not run in this environment.
