### PR TITLE
Harden AI-WOC send route validation

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -5,7 +5,18 @@ export async function POST(req: Request) {
   try {
     const { subject, emailBody, reportBody } = await req.json();
 
-    if (!subject || !emailBody || !reportBody) {
+    if (typeof subject !== 'string' || typeof emailBody !== 'string' || typeof reportBody !== 'string') {
+      return NextResponse.json(
+        { error: 'subject, emailBody, and reportBody are required.' },
+        { status: 400 }
+      );
+    }
+
+    const trimmedSubject = subject.trim();
+    const trimmedEmailBody = emailBody.trim();
+    const trimmedReportBody = reportBody.trim();
+
+    if (!trimmedSubject || !trimmedEmailBody || !trimmedReportBody) {
       return NextResponse.json(
         { error: 'subject, emailBody, and reportBody are required.' },
         { status: 400 }
@@ -24,14 +35,21 @@ export async function POST(req: Request) {
     }
 
     const resend = new Resend(apiKey);
-    const fullBody = `${emailBody}\n\n--------------------\nENGINEERING WORK ORDER CORRECTION REPORT\n--------------------\n\n${reportBody}`;
+    const fullBody = `${trimmedEmailBody}\n\n--------------------\nENGINEERING WORK ORDER CORRECTION REPORT\n--------------------\n\n${trimmedReportBody}`;
 
     const sent = await resend.emails.send({
       from,
       to,
-      subject,
+      subject: trimmedSubject,
       text: fullBody,
     });
+
+    if (sent.error) {
+      return NextResponse.json(
+        { error: 'Email provider rejected the request.' },
+        { status: 502 }
+      );
+    }
 
     return NextResponse.json({ success: true, id: sent.data?.id ?? null });
   } catch {


### PR DESCRIPTION
### Summary

- Keeps AI-WOC in its current lane and does not redesign the app.
- Hardens `app/api/send/route.ts` by validating `subject`, `emailBody`, and `reportBody` as strings before sending.
- Trims the outgoing subject, email body, and report body so blank whitespace cannot pass validation.
- Returns a clearer 502 response if Resend rejects the email request.
- Preserves the existing server-side environment variable requirements and missing-config error.

### Guardrails preserved

- Does not convert AI-WOC into AI-CIS.
- Does not add Lean Incident Reports, ROI reports, or case studies.
- Does not remove the draft/confirmation UI gate.
- Does not hard-code secrets or credentials.
- Does not change the default recipient.

### Testing

- Not run here. The ChatGPT execution sandbox could not clone from GitHub because direct GitHub DNS/network access is blocked.
- Recommended validation in Codex/Vercel: `npm install` and `npm run build`.