### PR TITLE
Implement M1 controlled submission layer

### DIFF
--- a/app/api/send/route.ts
+++ b/app/api/send/route.ts
@@ -3,22 +3,21 @@ import { Resend } from 'resend';
 
 export async function POST(req: Request) {
   try {
-    const { subject, emailBody, reportBody } = await req.json();
+    const { subject, emailBody } = await req.json();
 
-    if (typeof subject !== 'string' || typeof emailBody !== 'string' || typeof reportBody !== 'string') {
+    if (typeof subject !== 'string' || typeof emailBody !== 'string') {
       return NextResponse.json(
-        { error: 'subject, emailBody, and reportBody are required.' },
+        { error: 'subject and emailBody are required.' },
         { status: 400 }
       );
     }
 
     const trimmedSubject = subject.trim();
     const trimmedEmailBody = emailBody.trim();
-    const trimmedReportBody = reportBody.trim();
 
-    if (!trimmedSubject || !trimmedEmailBody || !trimmedReportBody) {
+    if (!trimmedSubject || !trimmedEmailBody) {
       return NextResponse.json(
-        { error: 'subject, emailBody, and reportBody are required.' },
+        { error: 'subject and emailBody are required.' },
         { status: 400 }
       );
     }
@@ -35,13 +34,11 @@ export async function POST(req: Request) {
     }
 
     const resend = new Resend(apiKey);
-    const fullBody = `${trimmedEmailBody}\n\n--------------------\nENGINEERING WORK ORDER CORRECTION REPORT\n--------------------\n\n${trimmedReportBody}`;
-
     const sent = await resend.emails.send({
       from,
       to,
       subject: trimmedSubject,
-      text: fullBody,
+      text: trimmedEmailBody,
     });
 
     if (sent.error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -243,6 +243,7 @@ export default function Home() {
       currentListedRate: current.currentListedRate || currentRate,
       observedBaseline: current.observedBaseline || baseline,
       issueType: 'Incorrect Time',
+      category: current.category || 'Welding',
       priority: 'High',
       problemSummary: `The current listed welding rate of ${currentRate} is not obtainable or sustainable under actual production conditions. A more balanced observed baseline is ${baseline}.`,
       requestedAction: `Please review and update the welding runtime/rate from ${currentRate} to a sustainable baseline of ${baseline}, or establish the correct Engineering-approved welding time.`,
@@ -406,6 +407,16 @@ ${emailBody}`;
   };
 
   const sendEmail = async () => {
+    if (!readyToDraft) {
+      setStatus('Core fields are missing. Fill all required fields before sending.');
+      return;
+    }
+
+    if (!allConfirmed) {
+      setStatus('Confirm every checkbox before sending.');
+      return;
+    }
+
     setSending(true);
     setStatus('');
 
@@ -615,7 +626,7 @@ ${emailBody}`;
               <button type="button" className="secondary" onClick={() => copyText(report)}>Copy Report</button>
               <button type="button" className="secondary" onClick={() => copyText(emailDraft)}>Copy Email</button>
             </div>
-            <button type="button" disabled={!allConfirmed || sending} onClick={sendEmail}>{sending ? 'Sending...' : 'Send Email'}</button>
+            <button type="button" disabled={!readyToDraft || !allConfirmed || sending} onClick={sendEmail}>{sending ? 'Sending...' : 'Send Email'}</button>
           </>
         ) : (
           <div className="empty-state">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,9 +14,28 @@ type WocData = {
   currentListedRate: string;
   observedBaseline: string;
   issueType: string;
+  category: string;
   priority: string;
   problemSummary: string;
   requestedAction: string;
+};
+
+type SubmissionRecord = {
+  wocId: string;
+  dateSubmitted: string;
+  submittedBy: string;
+  workOrderNumber: string;
+  partNumber: string;
+  departmentProcess: string;
+  issueType: string;
+  category: string;
+  priority: string;
+  requestedAction: string;
+  status: string;
+  assignedOwner: string;
+  engineeringNotes: string;
+  erpUpdated: boolean;
+  closedDate: string;
 };
 
 const DEFAULT_TO_EMAIL = 'Christophertroyhilton@gmail.com';
@@ -33,6 +52,7 @@ const blank: WocData = {
   currentListedRate: '',
   observedBaseline: '',
   issueType: 'Incorrect Time',
+  category: '',
   priority: 'Medium',
   problemSummary: '',
   requestedAction: '',
@@ -72,7 +92,8 @@ const issueOptions = [
   'Other',
 ];
 
-const priorityOptions = ['Low', 'Medium', 'High', 'Critical'];
+const categoryOptions = ['Welding', 'Machining', 'Fixtures', 'Routing', 'Material', 'Hardware', 'Quality', 'Other'];
+const priorityOptions = ['Low', 'Medium', 'High', 'Urgent'];
 
 const dataFields: [keyof WocData, string][] = [
   ['workOrder', 'Work Order Number'],
@@ -169,7 +190,8 @@ export default function Home() {
   const [checks, setChecks] = useState<boolean[]>(Array(5).fill(false));
   const [status, setStatus] = useState('');
   const [sending, setSending] = useState(false);
-  const [history, setHistory] = useState<string[]>([]);
+  const [history, setHistory] = useState<SubmissionRecord[]>([]);
+  const [nextWocId, setNextWocId] = useState(1);
 
   const setField = (field: keyof WocData, value: string) => {
     setData((current) => ({ ...current, [field]: value }));
@@ -189,6 +211,7 @@ export default function Home() {
       currentListedRate: '33 parts per hour',
       observedBaseline: '12.5 parts per hour',
       issueType: 'Incorrect Time',
+      category: 'Welding',
       priority: 'High',
       problemSummary: 'The current listed welding rate of 33 parts per hour is not obtainable or sustainable under actual production conditions.',
       requestedAction: 'Please review and update the welding runtime/rate from 33 parts per hour to a sustainable baseline of 12.5 parts per hour, or establish the correct Engineering-approved welding time.',
@@ -239,6 +262,9 @@ ${data.workOrder || '[WO REQUIRED]'} / ${data.partNumber || '[PART REQUIRED]'} �
 
 Correction Type:
 ${data.issueType}
+
+Category:
+${data.category || '[CATEGORY REQUIRED]'}
 
 Priority:
 ${data.priority}
@@ -307,8 +333,9 @@ ${today}`;
   }, [data, today]);
 
   const emailSubject = useMemo(() => {
-    return `Work Order Correction Request – ${data.workOrder || 'WO TBD'} / ${data.partNumber || 'Part TBD'} – ${data.issueType}`;
-  }, [data.issueType, data.partNumber, data.workOrder]);
+    const category = (data.category || 'CATEGORY TBD').toUpperCase();
+    return `[AI-WOC][${category}] WO ${data.workOrder || 'TBD'} | ${data.partNumber || 'PART TBD'} | ${data.issueType}`;
+  }, [data.category, data.issueType, data.partNumber, data.workOrder]);
 
   const emailBody = useMemo(() => {
     return `Engineering Team,
@@ -365,7 +392,7 @@ ${emailBody}`;
   }, [emailBody, emailSubject]);
 
   const allConfirmed = checks.every(Boolean);
-  const readyToDraft = Boolean(data.workOrder && data.partNumber && data.operation && data.process && data.problemSummary && data.requestedAction);
+  const readyToDraft = Boolean(data.workOrder && data.partNumber && data.operation && data.process && data.category && data.problemSummary && data.requestedAction);
 
   const copyText = async (text: string) => {
     await navigator.clipboard.writeText(text);
@@ -385,7 +412,7 @@ ${emailBody}`;
     const res = await fetch('/api/send', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ subject: emailSubject, emailBody, reportBody: report }),
+      body: JSON.stringify({ subject: emailSubject, emailBody }),
     });
 
     const result = await res.json();
@@ -393,8 +420,26 @@ ${emailBody}`;
     if (result.error) {
       setStatus(result.error);
     } else {
-      const record = `${new Date().toLocaleString()} – ${data.workOrder || 'WO TBD'} / ${data.partNumber || 'Part TBD'} sent`;
+      const wocId = `WOC-${String(nextWocId).padStart(4, '0')}`;
+      const record: SubmissionRecord = {
+        wocId,
+        dateSubmitted: new Date().toLocaleString(),
+        submittedBy: 'Chris',
+        workOrderNumber: data.workOrder || '',
+        partNumber: data.partNumber || '',
+        departmentProcess: `${data.department || '[N/A]'} / ${data.process || '[N/A]'}`,
+        issueType: data.issueType,
+        category: data.category,
+        priority: data.priority,
+        requestedAction: data.requestedAction,
+        status: 'Submitted',
+        assignedOwner: 'Engineering Queue',
+        engineeringNotes: '',
+        erpUpdated: false,
+        closedDate: '',
+      };
       setHistory((current) => [record, ...current].slice(0, 8));
+      setNextWocId((current) => current + 1);
       setStatus('Email sent successfully.');
     }
 
@@ -523,6 +568,13 @@ ${emailBody}`;
           </select>
         </label>
         <label>
+          Category
+          <select value={data.category} onChange={(event) => setField('category', event.target.value)}>
+            <option value="">Select category</option>
+            {categoryOptions.map((item) => <option key={item}>{item}</option>)}
+          </select>
+        </label>
+        <label>
           Priority
           <select value={data.priority} onChange={(event) => setField('priority', event.target.value)}>
             {priorityOptions.map((item) => <option key={item}>{item}</option>)}
@@ -581,7 +633,11 @@ ${emailBody}`;
         </div>
         {history.length ? (
           <ul className="history-list">
-            {history.map((item) => <li key={item}>{item}</li>)}
+            {history.map((item) => (
+              <li key={item.wocId}>
+                <strong>{item.wocId}</strong> — {item.dateSubmitted} — WO {item.workOrderNumber || 'TBD'} / {item.partNumber || 'TBD'} — {item.category} — {item.status}
+              </li>
+            ))}
           </ul>
         ) : (
           <p>Sent requests will appear here after email delivery is connected and tracking is added.</p>


### PR DESCRIPTION
### Motivation
- Provide the MVP Controlled Submission Layer (M1) to ensure correction requests include a required category, standardized priority, and consistent email routing metadata. 
- Create a simple local/session tracking mechanism (WOC IDs and records) so sent requests can be tracked in-session without adding a database. 
- Keep the existing compact one-page email behavior and confirmation-before-send gate while standardizing subject formatting for Engineering consumption.

### Description
- Added a required `category` field to the form state and report, introduced `categoryOptions` in the UI, and added the category to readiness checks so a missing category prevents send readiness. (changes in `app/page.tsx`).
- Replaced the priority options with `Low`, `Medium`, `High`, `Urgent` and preserved sample/template defaults at `High`. (changes in `app/page.tsx`).
- Standardized the outgoing email subject to `[AI-WOC][CATEGORY] WO ###### | PART ###### | ISSUE TYPE` using confirmed category, work order, part, and issue type. (changes in `app/page.tsx`).
- Implemented local/session WOC ID generation (`WOC-0001`, `WOC-0002`, ...) and a `SubmissionRecord` type plus an in-memory `history` array to store submitted records with the requested fields and defaults, and surfaced WOC ID and tracking info in the History UI. (changes in `app/page.tsx`).
- Preserved compact email behavior by removing the appended full report from outgoing messages and sending only the concise email body via the API; adjusted `app/api/send/route.ts` to accept `subject` and `emailBody` only. (changes in `app/api/send/route.ts`).
- Closes #18, Closes #19, Closes #20, Closes #21, Closes #22; Refs #15.

### Testing
- Ran `npm run build`, which completed successfully (compiled, lint/type checks passed, static pages generated) with no build-time errors. 
- The Next.js production build reported successful compilation and page generation during the automated build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a29c72448323b1e73b8757987ab3)