### PR TITLE
Fix #24: Split capture into Take Photo and Upload File/Picture

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -182,9 +182,11 @@ function extractRouterData(source: string, existing: WocData): WocData {
 }
 
 export default function Home() {
-  const captureInputRef = useRef<HTMLInputElement>(null);
+  const takePhotoInputRef = useRef<HTMLInputElement>(null);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
   const [data, setData] = useState<WocData>(blank);
   const [imageUrl, setImageUrl] = useState('');
+  const [selectedFileName, setSelectedFileName] = useState('');
   const [routerText, setRouterText] = useState('');
   const [showDraft, setShowDraft] = useState(false);
   const [checks, setChecks] = useState<boolean[]>(Array(5).fill(false));
@@ -393,6 +395,18 @@ ${emailBody}`;
   }, [emailBody, emailSubject]);
 
   const allConfirmed = checks.every(Boolean);
+
+  const onWorkOrderFileSelected = (file?: File) => {
+    if (!file) return;
+
+    setSelectedFileName(file.name);
+    if (file.type.startsWith('image/')) {
+      setImageUrl(URL.createObjectURL(file));
+      return;
+    }
+
+    setImageUrl('');
+  };
   const readyToDraft = Boolean(data.workOrder && data.partNumber && data.operation && data.process && data.category && data.problemSummary && data.requestedAction);
 
   const copyText = async (text: string) => {
@@ -513,24 +527,40 @@ ${emailBody}`;
         </div>
         <p className="mini-note">Use the camera/upload for evidence. For this MVP, paste copied router/OCR text below to auto-fill fields, then verify manually before sending.</p>
         <input
-          ref={captureInputRef}
+          ref={takePhotoInputRef}
           className="capture-input-hidden"
           type="file"
           accept="image/*"
           capture="environment"
           onChange={(event) => {
-            const file = event.target.files?.[0];
-            if (file) setImageUrl(URL.createObjectURL(file));
+            onWorkOrderFileSelected(event.target.files?.[0]);
           }}
         />
-        <button type="button" className="capture-trigger" onClick={() => captureInputRef.current?.click()}>
+        <input
+          ref={uploadInputRef}
+          className="capture-input-hidden"
+          type="file"
+          accept="image/*,application/pdf"
+          onChange={(event) => {
+            onWorkOrderFileSelected(event.target.files?.[0]);
+          }}
+        />
+        <button type="button" className="capture-trigger" onClick={() => takePhotoInputRef.current?.click()}>
           <span className="glass-icon-tile active">📷</span>
           <span>
-            <strong>Capture Work Order</strong>
-            <small>Take a photo or upload a work order image.</small>
+            <strong>Take Photo</strong>
+            <small>Use rear camera to capture work order.</small>
+          </span>
+        </button>
+        <button type="button" className="capture-trigger" onClick={() => uploadInputRef.current?.click()}>
+          <span className="glass-icon-tile">📁</span>
+          <span>
+            <strong>Upload File / Picture</strong>
+            <small>Select image or PDF from Photo Library or Files.</small>
           </span>
         </button>
         {imageUrl ? <img className="preview" src={imageUrl} alt="Uploaded work order preview" /> : null}
+        {!imageUrl && selectedFileName ? <p className="mini-note">Selected file: {selectedFileName}</p> : null}
         <label>
           Paste Router / OCR Text
           <textarea


### PR DESCRIPTION
### Motivation
- Improve mobile behavior by separating camera capture from generic file upload so iPhone/iPad can open Photo Library/Files when desired.
- Preserve existing preview behavior for images while preventing non-image files (e.g., PDFs) from being treated as images.
- Keep AI-WOC workflow, confirmation gating, and email/send logic unchanged.

### Description
- Replaced single capture input with two hidden inputs and buttons: a `Take Photo` input/button using `accept="image/*"` and `capture="environment"`, and an `Upload File / Picture` input/button without `capture` and `accept="image/*,application/pdf"` implemented in `app/page.tsx`.
- Added `uploadInputRef` and `takePhotoInputRef` refs and a unified handler `onWorkOrderFileSelected` to set `imageUrl` for image files and `selectedFileName` for non-image files.
- Preserved image preview logic (`<img className="preview" ... />`) for images and display the selected filename when a non-image file (like a PDF) is chosen.
- Did not modify any workflow, confirmation-checking, email drafting, or send logic.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b494fafc8323a703718b238caebf)