### PR TITLE
HOTFIX: Restore photo auto-extract behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useRef, useState } from 'react';
 
+
+
 type WocData = {
   workOrder: string;
   partNumber: string;
@@ -194,6 +196,7 @@ export default function Home() {
   const [sending, setSending] = useState(false);
   const [history, setHistory] = useState<SubmissionRecord[]>([]);
   const [nextWocId, setNextWocId] = useState(1);
+  const [ocrRunning, setOcrRunning] = useState(false);
 
   const setField = (field: keyof WocData, value: string) => {
     setData((current) => ({ ...current, [field]: value }));
@@ -396,16 +399,49 @@ ${emailBody}`;
 
   const allConfirmed = checks.every(Boolean);
 
-  const onWorkOrderFileSelected = (file?: File) => {
+  const runOcrFromImage = async (file: File) => {
+    setStatus('Reading work order image...');
+    setOcrRunning(true);
+
+    try {
+      const detectorCtor = (window as typeof window & { TextDetector?: new () => { detect: (image: ImageBitmap) => Promise<Array<{ rawValue?: string }>> } }).TextDetector;
+
+      if (!detectorCtor) {
+        setStatus('OCR could not reliably read this image. Enter or paste text manually.');
+        return;
+      }
+
+      const imageBitmap = await createImageBitmap(file);
+      const detector = new detectorCtor();
+      const blocks = await detector.detect(imageBitmap);
+      const extracted = blocks.map((block) => block.rawValue ?? '').join('\n').trim();
+
+      if (!extracted) {
+        setStatus('OCR could not reliably read this image. Enter or paste text manually.');
+        return;
+      }
+
+      setRouterText(extracted);
+      setStatus('OCR text extracted. Review fields before sending.');
+    } catch {
+      setStatus('OCR could not reliably read this image. Enter or paste text manually.');
+    } finally {
+      setOcrRunning(false);
+    }
+  };
+
+  const onWorkOrderFileSelected = async (file?: File) => {
     if (!file) return;
 
     setSelectedFileName(file.name);
     if (file.type.startsWith('image/')) {
       setImageUrl(URL.createObjectURL(file));
+      await runOcrFromImage(file);
       return;
     }
 
     setImageUrl('');
+    setStatus('OCR could not reliably read this image. Enter or paste text manually.');
   };
   const hasPartNumber = Boolean(data.partNumber.trim());
   const hasWorkOrder = Boolean(data.workOrder.trim());
@@ -545,7 +581,7 @@ ${emailBody}`;
           <p>Step 1</p>
           <h2>Capture Work Order</h2>
         </div>
-        <p className="mini-note">Use the camera/upload for evidence. For this MVP, paste copied router/OCR text below to auto-fill fields, then verify manually before sending.</p>
+        <p className="mini-note">Use the camera/upload to auto-read router text when possible. If OCR is unclear, paste or type router text manually, then verify before sending.</p>
         <input
           ref={takePhotoInputRef}
           className="capture-input-hidden"
@@ -589,8 +625,9 @@ ${emailBody}`;
             placeholder="Paste copied text from the work order here. Example: WO 042631-001, Part CYM-1750-LH-BU, Operation 003000 L WD10, Rate 33 parts per hour..."
           />
         </label>
+        {ocrRunning ? <p className="mini-note">Reading work order image...</p> : null}
         <div className="button-row">
-          <button type="button" className="secondary" onClick={extractData}>
+          <button type="button" className="secondary" onClick={extractData} disabled={ocrRunning}>
             Extract Data
           </button>
           <button type="button" onClick={loadSample}>Load Sample</button>
@@ -680,7 +717,8 @@ ${emailBody}`;
                 {label}
               </label>
             ))}
-            <div className="button-row">
+            {ocrRunning ? <p className="mini-note">Reading work order image...</p> : null}
+        <div className="button-row">
               <button type="button" className="secondary" onClick={() => copyText(report)}>Copy Report</button>
               <button type="button" className="secondary" onClick={() => copyText(emailDraft)}>Copy Email</button>
             </div>


### PR DESCRIPTION
### Motivation
- Restore the fast capture path so taking a photo or uploading an image attempts OCR/extraction immediately instead of only previewing the image. 
- Preserve the loosened readiness/confirmation rules and avoid any changes to send routes, database/storage, or auto-send behavior.

### Description
- Add an `ocrRunning` state and a new `runOcrFromImage(file)` function that uses the browser `TextDetector` when available to extract text from selected images and set `routerText` with the result. 
- Call `runOcrFromImage` from `onWorkOrderFileSelected` when an image is selected and show the image preview via `setImageUrl`; keep manual paste entry available and reuse the existing `Extract Data`/`extractRouterData` flow. 
- Implement explicit status messages (`Reading work order image...`, `OCR text extracted. Review fields before sending.`, and `OCR could not reliably read this image. Enter or paste text manually.`) and temporarily disable the `Extract Data` button while OCR is running. 
- Update the capture panel copy to reflect the auto-read behavior and ensure no changes to the email/send gating logic or storage paths. (Changes in `app/page.tsx`.)

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with pages generated and compilation passing. 
- The build includes TypeScript checking/linting steps performed by the build and there were no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f336a6fd7483239d8d060025d88b8b)