### PR TITLE
HOTFIX: Clarify photo evidence flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -196,7 +196,6 @@ export default function Home() {
   const [sending, setSending] = useState(false);
   const [history, setHistory] = useState<SubmissionRecord[]>([]);
   const [nextWocId, setNextWocId] = useState(1);
-  const [ocrRunning, setOcrRunning] = useState(false);
 
   const setField = (field: keyof WocData, value: string) => {
     setData((current) => ({ ...current, [field]: value }));
@@ -228,7 +227,7 @@ export default function Home() {
 
   const extractData = () => {
     if (!routerText.trim()) {
-      setStatus('Capture or upload the work order, then paste copied/OCR router text here for auto-fill. Manual entry still works.');
+      setStatus('Photo is saved as evidence. To auto-fill fields, paste copied/OCR text here or enter fields manually.');
       return;
     }
 
@@ -399,49 +398,18 @@ ${emailBody}`;
 
   const allConfirmed = checks.every(Boolean);
 
-  const runOcrFromImage = async (file: File) => {
-    setStatus('Reading work order image...');
-    setOcrRunning(true);
-
-    try {
-      const detectorCtor = (window as typeof window & { TextDetector?: new () => { detect: (image: ImageBitmap) => Promise<Array<{ rawValue?: string }>> } }).TextDetector;
-
-      if (!detectorCtor) {
-        setStatus('OCR could not reliably read this image. Enter or paste text manually.');
-        return;
-      }
-
-      const imageBitmap = await createImageBitmap(file);
-      const detector = new detectorCtor();
-      const blocks = await detector.detect(imageBitmap);
-      const extracted = blocks.map((block) => block.rawValue ?? '').join('\n').trim();
-
-      if (!extracted) {
-        setStatus('OCR could not reliably read this image. Enter or paste text manually.');
-        return;
-      }
-
-      setRouterText(extracted);
-      setStatus('OCR text extracted. Review fields before sending.');
-    } catch {
-      setStatus('OCR could not reliably read this image. Enter or paste text manually.');
-    } finally {
-      setOcrRunning(false);
-    }
-  };
-
-  const onWorkOrderFileSelected = async (file?: File) => {
+  const onWorkOrderFileSelected = (file?: File) => {
     if (!file) return;
 
     setSelectedFileName(file.name);
     if (file.type.startsWith('image/')) {
       setImageUrl(URL.createObjectURL(file));
-      await runOcrFromImage(file);
+      setStatus('Photo is saved as evidence. To auto-fill fields, paste copied/OCR text here or enter fields manually.');
       return;
     }
 
     setImageUrl('');
-    setStatus('OCR could not reliably read this image. Enter or paste text manually.');
+    setStatus('Attachment added. To auto-fill fields, paste copied/OCR text here or enter fields manually.');
   };
   const hasPartNumber = Boolean(data.partNumber.trim());
   const hasWorkOrder = Boolean(data.workOrder.trim());
@@ -581,7 +549,7 @@ ${emailBody}`;
           <p>Step 1</p>
           <h2>Capture Work Order</h2>
         </div>
-        <p className="mini-note">Use the camera/upload to auto-read router text when possible. If OCR is unclear, paste or type router text manually, then verify before sending.</p>
+        <p className="mini-note">Photo is saved as evidence. To auto-fill fields, paste copied/OCR text here or enter fields manually.</p>
         <input
           ref={takePhotoInputRef}
           className="capture-input-hidden"
@@ -625,10 +593,9 @@ ${emailBody}`;
             placeholder="Paste copied text from the work order here. Example: WO 042631-001, Part CYM-1750-LH-BU, Operation 003000 L WD10, Rate 33 parts per hour..."
           />
         </label>
-        {ocrRunning ? <p className="mini-note">Reading work order image...</p> : null}
         <div className="button-row">
-          <button type="button" className="secondary" onClick={extractData} disabled={ocrRunning}>
-            Extract Data
+          <button type="button" className="secondary" onClick={extractData}>
+            Extract From Text
           </button>
           <button type="button" onClick={loadSample}>Load Sample</button>
         </div>
@@ -717,7 +684,6 @@ ${emailBody}`;
                 {label}
               </label>
             ))}
-            {ocrRunning ? <p className="mini-note">Reading work order image...</p> : null}
         <div className="button-row">
               <button type="button" className="secondary" onClick={() => copyText(report)}>Copy Report</button>
               <button type="button" className="secondary" onClick={() => copyText(emailDraft)}>Copy Email</button>


### PR DESCRIPTION
### Motivation
- Remove unreliable in-browser OCR attempts that produced confusing failure messages on iPhone/Safari and make the capture flow explicit and honest.
- Treat captured photos and uploaded files as visual evidence/attachments only while keeping text extraction tied to the Paste Router / OCR Text box.
- Preserve the manual-entry-first UX, send/confirmation gate, and loosened readiness rules from earlier PRs.

### Description
- Removed the automatic OCR flow and the `TextDetector` usage by deleting the `runOcrFromImage` logic and the `ocrRunning` state, and stopped invoking OCR on file selection in `app/page.tsx`.
- Updated the file-selection handler `onWorkOrderFileSelected` to only create an image preview and set clear helper status messages indicating that photos are evidence and that pasted text drives extraction.
- Rewrote helper copy in the capture panel to: `Photo is saved as evidence. To auto-fill fields, paste copied/OCR text here or enter fields manually.`, and renamed the extraction button from `Extract Data` to `Extract From Text` to clarify behavior.
- Preserved image preview, upload behavior, textarea-based extraction (`extractRouterData`), manual fields, readiness/send gating, and the existing `/api/send` route and confirmation flow.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with pages generated and type/lint checks included in the build step.
- Verified the app compiles and the UI shows image preview and updated helper/status copy without any OCR attempts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33e844b8c8323834661fd79db8c68)