### PR TITLE
Add quick-entry fields under photo capture

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -452,6 +452,43 @@ button:disabled { opacity: 0.45; }
   border: 1px solid rgba(202, 209, 217, 0.35);
 }
 
+.quick-entry-card {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(202, 209, 217, 0.28);
+  background: rgba(12, 14, 19, 0.82);
+}
+
+.quick-entry-card h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.quick-entry-card p {
+  margin: 6px 0 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.quick-entry-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.quick-entry-grid label {
+  margin: 0;
+}
+
+.quick-entry-grid textarea {
+  min-height: 86px;
+}
+
+.quick-entry-full {
+  grid-column: 1 / -1;
+}
+
 pre {
   white-space: pre-wrap;
   overflow-wrap: anywhere;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -585,6 +585,59 @@ ${emailBody}`;
         </button>
         {imageUrl ? <img className="preview" src={imageUrl} alt="Uploaded work order preview" /> : null}
         {!imageUrl && selectedFileName ? <p className="mini-note">Selected file: {selectedFileName}</p> : null}
+        <div className="quick-entry-card">
+          <h3>Quick Entry</h3>
+          <p>Enter the printed header and issue details while viewing the work order image.</p>
+          <div className="quick-entry-grid">
+            <label>
+              Work Order Number
+              <input value={data.workOrder} onChange={(event) => setField('workOrder', event.target.value)} />
+            </label>
+            <label>
+              Part Number
+              <input value={data.partNumber} onChange={(event) => setField('partNumber', event.target.value)} />
+            </label>
+            <label>
+              Revision
+              <input value={data.revision} onChange={(event) => setField('revision', event.target.value)} />
+            </label>
+            <label>
+              Customer
+              <input value={data.customer} onChange={(event) => setField('customer', event.target.value)} />
+            </label>
+            <label>
+              Quantity
+              <input value={data.quantity} onChange={(event) => setField('quantity', event.target.value)} />
+            </label>
+            <label>
+              Category
+              <select value={data.category} onChange={(event) => setField('category', event.target.value)}>
+                <option value="">Select category</option>
+                {categoryOptions.map((item) => <option key={item}>{item}</option>)}
+              </select>
+            </label>
+            <label>
+              Issue Type
+              <select value={data.issueType} onChange={(event) => setField('issueType', event.target.value)}>
+                {issueOptions.map((item) => <option key={item}>{item}</option>)}
+              </select>
+            </label>
+            <label>
+              Priority
+              <select value={data.priority} onChange={(event) => setField('priority', event.target.value)}>
+                {priorityOptions.map((item) => <option key={item}>{item}</option>)}
+              </select>
+            </label>
+            <label className="quick-entry-full">
+              Problem Summary
+              <textarea value={data.problemSummary} onChange={(event) => setField('problemSummary', event.target.value)} />
+            </label>
+            <label className="quick-entry-full">
+              Requested Engineering Action
+              <textarea value={data.requestedAction} onChange={(event) => setField('requestedAction', event.target.value)} />
+            </label>
+          </div>
+        </div>
         <label>
           Paste Router / OCR Text
           <textarea


### PR DESCRIPTION
### Motivation
- Provide a compact, mobile-first quick-entry UI directly beneath the photo preview so operators can type the printed ERP header and basic issue fields while viewing the captured work order image.
- Maintain the existing flow, data model, preview, upload, paste/Extract behavior, confirmation gate, and send route without adding OCR or duplicating state.

### Description
- Adds a new `Quick Entry` card under the photo preview that exposes header fields (`Work Order Number`, `Part Number`, `Revision`, `Customer`, `Quantity`) and issue fields (`Category`, `Issue Type`, `Priority`, `Problem Summary`, `Requested Engineering Action`).
- Wires all quick-entry inputs to the existing `data` state via the existing `setField` helper so updates immediately reflect in the existing `Confirm Data` and `State Issue` sections and avoid duplicating fields.
- Introduces compact styling for the quick-entry card and grid in `app/globals.css` to keep the UI phone-friendly and compact.
- Preserves upload/preview, Paste Router / Extract From Text behavior, confirmation gating, email send route, and existing readiness rules; no OCR or route changes were added.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully with compilation, linting, and type checks passing.
- Static page generation succeeded and the build output reported generated routes without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34dc57f008323858f62ed4b01c3f3)