### PR TITLE
Make status message non-blocking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import './woc.css';
 import './responsive-polish.css';
+import './status-toast.css';
 
 export const metadata: Metadata = {
   title: 'REFAB Connect',

--- a/app/status-toast.css
+++ b/app/status-toast.css
@@ -1,0 +1,40 @@
+.status {
+  top: max(14px, calc(env(safe-area-inset-top) + 10px));
+  bottom: auto;
+  left: 18px;
+  right: 18px;
+  z-index: 45;
+  max-width: 520px;
+  padding: 10px 12px;
+  font-size: 14px;
+  line-height: 1.35;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-8px);
+  animation: status-toast-in-out 3.2s ease forwards;
+}
+
+@keyframes status-toast-in-out {
+  0% {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  10%, 78% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+  }
+}
+
+@media (max-width: 620px) {
+  .status {
+    left: 14px;
+    right: 14px;
+    max-width: none;
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a small `status-toast.css` override so status messages appear near the top of the screen instead of covering Quick Entry fields.
- Makes the toast non-blocking with `pointer-events: none`.
- Auto-dismisses the toast visually after about 3 seconds.
- Preserves Quick Entry, photo preview, loosened readiness rules, send route, and confirmation gate.

## Testing
- Not run locally in this environment. Please verify Vercel build.

Closes #39