### PR TITLE
Add backend OpenAI Vision header extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 RESEND_API_KEY=
 AI_WOC_FROM_EMAIL=
 AI_WOC_DEFAULT_TO_EMAIL=Christophertroyhilton@gmail.com
+
+OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Do not commit `.env.local` or any real API keys.
 RESEND_API_KEY=
 AI_WOC_FROM_EMAIL=
 AI_WOC_DEFAULT_TO_EMAIL=Christophertroyhilton@gmail.com
+OPENAI_API_KEY=your_openai_api_key_here
 ```
 
 `RESEND_API_KEY` is used only by the server-side send route.
+
+`OPENAI_API_KEY` is used only by the server-side `/api/extract-vision` route for AI Vision header extraction.
 
 `AI_WOC_FROM_EMAIL` must be a sender address approved by the email provider.
 

--- a/app/api/extract-vision/route.ts
+++ b/app/api/extract-vision/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from 'next/server';
+
+const MODEL = 'gpt-4.1-mini';
+
+const visionPrompt = `You are reading a manufacturing ERP router header. Extract only visible header fields. Do not guess. If uncertain, leave blank and add the field name to needsReview.
+
+Fields:
+Work Order, Description, Due Date, Quantity, UO, Sales Order, Part Number, Rev, Customer Name, Cust Number, Cust PO Number, CAD Drawing.
+
+Normalize:
+- Split work order like 042603 002 to 042603-002 when clearly shown as a work order.
+- Quantity should include UO if visible, like 500.00 EA.
+- Customer should not include date or quantity values.
+- CAD Drawing should not overwrite Part Number unless part number is blank.
+
+Return strict JSON with only:
+workOrder, partNumber, revision, customer, quantity, salesOrder, customerPo, cadDrawing, confidence, needsReview`;
+
+type VisionResult = {
+  workOrder: string;
+  partNumber: string;
+  revision: string;
+  customer: string;
+  quantity: string;
+  salesOrder: string;
+  customerPo: string;
+  cadDrawing: string;
+  confidence: number;
+  needsReview: string[];
+};
+
+const emptyResult: VisionResult = {
+  workOrder: '',
+  partNumber: '',
+  revision: '',
+  customer: '',
+  quantity: '',
+  salesOrder: '',
+  customerPo: '',
+  cadDrawing: '',
+  confidence: 0,
+  needsReview: [],
+};
+
+function sanitizeResult(raw: unknown): VisionResult {
+  const value = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {};
+  const cleanText = (input: unknown) => typeof input === 'string' ? input.trim() : '';
+  const confidence = typeof value.confidence === 'number' ? Math.max(0, Math.min(1, value.confidence)) : 0;
+
+  return {
+    workOrder: cleanText(value.workOrder),
+    partNumber: cleanText(value.partNumber),
+    revision: cleanText(value.revision),
+    customer: cleanText(value.customer),
+    quantity: cleanText(value.quantity),
+    salesOrder: cleanText(value.salesOrder),
+    customerPo: cleanText(value.customerPo),
+    cadDrawing: cleanText(value.cadDrawing),
+    confidence,
+    needsReview: Array.isArray(value.needsReview)
+      ? value.needsReview.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
+      : [],
+  };
+}
+
+export async function POST(request: Request) {
+  try {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: 'Missing OPENAI_API_KEY on server.' }, { status: 500 });
+    }
+
+    const formData = await request.formData();
+    const image = formData.get('image');
+
+    if (!(image instanceof File)) {
+      return NextResponse.json({ error: 'Image file is required.' }, { status: 400 });
+    }
+
+    if (!image.type.startsWith('image/')) {
+      return NextResponse.json({ error: 'Only image uploads are supported.' }, { status: 400 });
+    }
+
+    const bytes = Buffer.from(await image.arrayBuffer());
+    const dataUrl = `data:${image.type};base64,${bytes.toString('base64')}`;
+
+    const openAiResponse = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        input: [
+          {
+            role: 'user',
+            content: [
+              { type: 'input_text', text: visionPrompt },
+              { type: 'input_image', image_url: dataUrl },
+            ],
+          },
+        ],
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'router_header_extraction',
+            schema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                workOrder: { type: 'string' },
+                partNumber: { type: 'string' },
+                revision: { type: 'string' },
+                customer: { type: 'string' },
+                quantity: { type: 'string' },
+                salesOrder: { type: 'string' },
+                customerPo: { type: 'string' },
+                cadDrawing: { type: 'string' },
+                confidence: { type: 'number' },
+                needsReview: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['workOrder', 'partNumber', 'revision', 'customer', 'quantity', 'salesOrder', 'customerPo', 'cadDrawing', 'confidence', 'needsReview'],
+            },
+            strict: true,
+          },
+        },
+      }),
+    });
+
+    if (!openAiResponse.ok) {
+      const errText = await openAiResponse.text();
+      return NextResponse.json({ error: `OpenAI request failed: ${errText}` }, { status: 502 });
+    }
+
+    const payload = await openAiResponse.json() as { output_text?: string };
+    const raw = payload.output_text ? JSON.parse(payload.output_text) : emptyResult;
+
+    return NextResponse.json(sanitizeResult(raw));
+  } catch (_error) {
+    return NextResponse.json({ error: 'Vision extraction failed.' }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -233,6 +233,7 @@ export default function Home() {
   const [selectedFileName, setSelectedFileName] = useState('');
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
   const [ocrLoading, setOcrLoading] = useState(false);
+  const [visionLoading, setVisionLoading] = useState(false);
   const [routerText, setRouterText] = useState('');
   const [showDraft, setShowDraft] = useState(false);
   const [checks, setChecks] = useState<boolean[]>(Array(5).fill(false));
@@ -332,6 +333,51 @@ export default function Home() {
       setOcrLoading(false);
     }
   };
+
+
+  const extractWithVision = async () => {
+    if (!selectedImageFile || visionLoading) return;
+
+    setVisionLoading(true);
+    setStatus('Extracting header with AI Vision...');
+
+    try {
+      const formData = new FormData();
+      formData.append('image', selectedImageFile);
+
+      const response = await fetch('/api/extract-vision', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(result?.error || 'Vision extraction failed.');
+      }
+
+      setData((current) => ({
+        ...current,
+        workOrder: result.workOrder || current.workOrder,
+        partNumber: result.partNumber || current.partNumber || result.cadDrawing || '',
+        revision: result.revision || current.revision,
+        customer: result.customer || current.customer,
+        quantity: result.quantity || current.quantity,
+      }));
+      setChecks(Array(5).fill(false));
+
+      if (Array.isArray(result.needsReview) && result.needsReview.length) {
+        setStatus(`AI Vision extracted header. Review: ${result.needsReview.join(', ')}.`);
+      } else {
+        setStatus('AI Vision extracted header fields. Verify before generating draft.');
+      }
+    } catch (_error) {
+      setStatus('AI Vision extraction failed. Try Basic OCR Fallback or enter fields manually.');
+    } finally {
+      setVisionLoading(false);
+    }
+  };
+
   const applyWeldingTimeTemplate = () => {
     const currentRate = data.currentListedRate || '33 parts per hour';
     const baseline = data.observedBaseline || '12.5 parts per hour';
@@ -682,14 +728,24 @@ ${emailBody}`;
           </span>
         </button>
         {imageUrl ? <img className="preview" src={imageUrl} alt="Uploaded work order preview" /> : null}
-        <button
-          type="button"
-          className="secondary"
-          disabled={!selectedImageFile || ocrLoading}
-          onClick={extractTextFromPhoto}
-        >
-          {ocrLoading ? 'Extracting Text…' : 'Extract Text From Photo'}
-        </button>
+        <div className="button-row">
+          <button
+            type="button"
+            className="secondary"
+            disabled={!selectedImageFile || visionLoading}
+            onClick={extractWithVision}
+          >
+            {visionLoading ? 'Extracting Vision…' : 'Extract With AI Vision'}
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            disabled={!selectedImageFile || ocrLoading}
+            onClick={extractTextFromPhoto}
+          >
+            {ocrLoading ? 'Extracting Text…' : 'Basic OCR Fallback'}
+          </button>
+        </div>
         {!imageUrl && selectedFileName ? <p className="mini-note">Selected file: {selectedFileName}</p> : null}
         <div className="quick-entry-card">
           <h3>Quick Entry</h3>


### PR DESCRIPTION
### Motivation

- Enable AI-powered extraction of router header fields from photos while keeping the OpenAI API key server-side and preserving the manual confirmation/send workflow.
- Provide a higher-quality vision extraction path in addition to the existing client-side Tesseract fallback without storing uploaded photos or changing ERP/send logic.

### Description

- Added a server-only route `POST /api/extract-vision` implemented at `app/api/extract-vision/route.ts` that accepts an image via `FormData`, converts it to an in-memory base64 data URL, calls the OpenAI Responses API (`gpt-4.1-mini`) with a JSON-schema constrained prompt, and returns strict JSON with `workOrder`, `partNumber`, `revision`, `customer`, `quantity`, `salesOrder`, `customerPo`, `cadDrawing`, `confidence`, and `needsReview`.
- Updated the client (`app/page.tsx`) to add an "Extract With AI Vision" button and `visionLoading` state, implemented `extractWithVision()` to POST the selected image to `/api/extract-vision` and populate the Quick Entry fields while preserving the confirmation gate and send flow.
- Kept the existing OCR path as a fallback and relabeled it to "Basic OCR Fallback"; preserved the existing "Extract From Text" and Quick Entry behavior.
- Updated `.env.example` and `README.md` to document `OPENAI_API_KEY` and that it is used only by the server-side `/api/extract-vision` route; images are not persisted on disk.

### Testing

- Ran `npm run build`, which completed successfully with Next.js producing the app and the new dynamic route included in the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b14e0ab48323bff0a96ff3cdad85)