### PR TITLE
Add persistent AI Vision extraction status panel

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -444,6 +444,41 @@ button.secondary {
 
 button:disabled { opacity: 0.45; }
 .button-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.vision-status-card {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(202, 209, 217, 0.3);
+  background: rgba(12, 14, 19, 0.88);
+}
+
+.vision-status-card p {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.vision-status-card dl {
+  margin: 8px 0 0;
+  display: grid;
+  gap: 4px;
+}
+
+.vision-status-card dl div {
+  display: grid;
+  grid-template-columns: 94px 1fr;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.vision-status-card dt {
+  color: var(--muted);
+}
+
+.vision-status-card dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
 
 .preview {
   width: 100%;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -261,6 +261,15 @@ export default function Home() {
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
   const [ocrLoading, setOcrLoading] = useState(false);
   const [visionLoading, setVisionLoading] = useState(false);
+  const [visionDebugMessage, setVisionDebugMessage] = useState('');
+  const [lastVisionResult, setLastVisionResult] = useState<{
+    workOrder: string;
+    partNumber: string;
+    revision: string;
+    customer: string;
+    quantity: string;
+    needsReview: string[];
+  } | null>(null);
   const [routerText, setRouterText] = useState('');
   const [showDraft, setShowDraft] = useState(false);
   const [checks, setChecks] = useState<boolean[]>(Array(5).fill(false));
@@ -366,11 +375,14 @@ export default function Home() {
     if (!selectedImageFile || visionLoading) return;
 
     setVisionLoading(true);
+    setVisionDebugMessage('AI Vision started...');
+    setLastVisionResult(null);
     setStatus('Extracting header with AI Vision...');
 
     try {
       const formData = new FormData();
       formData.append('image', selectedImageFile);
+      setVisionDebugMessage('Sending image to backend...');
 
       const response = await fetch('/api/extract-vision', {
         method: 'POST',
@@ -392,6 +404,15 @@ export default function Home() {
         quantity: result.quantity || current.quantity,
       }));
       setChecks(Array(5).fill(false));
+      setLastVisionResult({
+        workOrder: result.workOrder || '',
+        partNumber: result.partNumber || result.cadDrawing || '',
+        revision: result.revision || '',
+        customer: result.customer || '',
+        quantity: result.quantity || '',
+        needsReview: Array.isArray(result.needsReview) ? result.needsReview : [],
+      });
+      setVisionDebugMessage('AI Vision success. Fields updated.');
 
       if (Array.isArray(result.needsReview) && result.needsReview.length) {
         setStatus(`AI Vision extracted header. Review: ${result.needsReview.join(', ')}.`);
@@ -400,6 +421,8 @@ export default function Home() {
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'AI Vision extraction failed.';
+      const safeMessage = message.replace(/\s+/g, ' ').trim().slice(0, 180);
+      setVisionDebugMessage(`AI Vision error: ${safeMessage}`);
       setStatus(`${message} Try Basic OCR Fallback or enter fields manually.`);
     } finally {
       setVisionLoading(false);
@@ -774,6 +797,21 @@ ${emailBody}`;
             {ocrLoading ? 'Extracting Text…' : 'Basic OCR Fallback'}
           </button>
         </div>
+        {visionDebugMessage ? (
+          <div className="vision-status-card" role="status" aria-live="polite">
+            <p>{visionDebugMessage}</p>
+            {lastVisionResult ? (
+              <dl>
+                <div><dt>Work Order</dt><dd>{lastVisionResult.workOrder || '—'}</dd></div>
+                <div><dt>Part Number</dt><dd>{lastVisionResult.partNumber || '—'}</dd></div>
+                <div><dt>Revision</dt><dd>{lastVisionResult.revision || '—'}</dd></div>
+                <div><dt>Customer</dt><dd>{lastVisionResult.customer || '—'}</dd></div>
+                <div><dt>Quantity</dt><dd>{lastVisionResult.quantity || '—'}</dd></div>
+                <div><dt>Needs Review</dt><dd>{lastVisionResult.needsReview.length ? lastVisionResult.needsReview.join(', ') : 'None'}</dd></div>
+              </dl>
+            ) : null}
+          </div>
+        ) : null}
         {!imageUrl && selectedFileName ? <p className="mini-note">Selected file: {selectedFileName}</p> : null}
         <div className="quick-entry-card">
           <h3>Quick Entry</h3>


### PR DESCRIPTION
### Motivation
- Tapping `Extract With AI Vision` produced no persistent feedback in the UI making it hard to trace whether the button fired or what the backend returned. 
- A compact, durable inline status is required under the Vision/OCR buttons so mobile users can see progress, success, or a safe error message without relying on fleeting toasts. 
- The change aims to make AI Vision extraction visibly traceable from the phone UI while preserving existing capture, OCR, quick/manual entry, drafting, and send flows.

### Description
- Added two pieces of state in `app/page.tsx`: `visionDebugMessage` and `lastVisionResult` to record staged progress and the latest parsed JSON result respectively. 
- Updated `extractWithVision` to set milestone messages (`AI Vision started...`, `Sending image to backend...`), capture a compact safe error text, and populate `lastVisionResult` on success. 
- Inserted a persistent inline status/result card directly under the `Extract With AI Vision` / `Basic OCR Fallback` button row that shows the latest message and a compact debug summary (`Work Order`, `Part Number`, `Revision`, `Customer`, `Quantity`, `Needs Review`). 
- Added mobile-friendly styling in `app/globals.css` for the `.vision-status-card` to keep the card compact and readable and left all existing flows and server-side secrets unchanged.

### Testing
- Ran the production build with `npm run build` which completed successfully and generated optimized pages. 
- Confirmed the app compiles and pages are produced during the Next.js build (no runtime tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47a4fdc708323841ecce10ca789aa)