### PR TITLE
Normalize image before AI Vision extraction

### DIFF
--- a/app/api/extract-vision/route.ts
+++ b/app/api/extract-vision/route.ts
@@ -128,6 +128,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Uploaded file must be an image.' }, { status: 400 });
     }
 
+    if (image.size > 10 * 1024 * 1024) {
+      return NextResponse.json(
+        { error: 'Image is too large for AI Vision. Try a closer/cropped header photo.' },
+        { status: 413 },
+      );
+    }
+
     const bytes = Buffer.from(await image.arrayBuffer());
     const dataUrl = `data:${image.type};base64,${bytes.toString('base64')}`;
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -252,6 +252,46 @@ function extractRouterData(source: string, existing: WocData): WocData {
   };
 }
 
+async function prepareImageForVision(file: File): Promise<File> {
+  let objectUrl = '';
+  try {
+    objectUrl = URL.createObjectURL(file);
+    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('Unable to load image for vision preparation.'));
+      img.src = objectUrl;
+    });
+
+    const maxSide = 1600;
+    const longestSide = Math.max(image.width, image.height);
+    const scale = longestSide > maxSide ? maxSide / longestSide : 1;
+    const targetWidth = Math.max(1, Math.round(image.width * scale));
+    const targetHeight = Math.max(1, Math.round(image.height * scale));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return file;
+    }
+
+    context.drawImage(image, 0, 0, targetWidth, targetHeight);
+
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob((result) => resolve(result), 'image/jpeg', 0.85);
+    });
+
+    if (!blob) return file;
+    return new File([blob], 'vision-header.jpg', { type: 'image/jpeg' });
+  } catch {
+    return file;
+  } finally {
+    if (objectUrl) URL.revokeObjectURL(objectUrl);
+  }
+}
+
 export default function Home() {
   const takePhotoInputRef = useRef<HTMLInputElement>(null);
   const uploadInputRef = useRef<HTMLInputElement>(null);
@@ -380,8 +420,10 @@ export default function Home() {
     setStatus('Extracting header with AI Vision...');
 
     try {
+      setVisionDebugMessage('Preparing image for AI Vision...');
+      const imageForVision = await prepareImageForVision(selectedImageFile);
       const formData = new FormData();
-      formData.append('image', selectedImageFile);
+      formData.append('image', imageForVision);
       setVisionDebugMessage('Sending image to backend...');
 
       const response = await fetch('/api/extract-vision', {


### PR DESCRIPTION
### Motivation
- Reduce failed AI Vision requests caused by very large or odd-format iPhone images by normalizing and compressing client-side before sending to the Vision backend.
- Ensure the AI Vision flow remains debuggable and safe while preserving the existing fallback OCR and error handling behavior.

### Description
- Added `prepareImageForVision(file: File): Promise<File>` in `app/page.tsx` which loads an image, draws it to a canvas, resizes the longest side to a maximum of `1600` pixels while preserving aspect ratio, converts to JPEG via `canvas.toBlob` at `quality: 0.85`, and returns a `File` named `vision-header.jpg`, falling back to the original file on failure.
- Updated `extractWithVision()` in `app/page.tsx` to call `prepareImageForVision(selectedImageFile)` before appending the file to `FormData` and to show inline debug messages `"Preparing image for AI Vision..."` then `"Sending image to backend..."` while keeping the persistent AI Vision debug panel.
- Added a backend guard in `app/api/extract-vision/route.ts` to reject uploads larger than `10MB` with HTTP `413` and the message `"Image is too large for AI Vision. Try a closer/cropped header photo."`.
- Preserved safe server-side error redaction, the Basic OCR fallback, the send/email route, and the user confirmation gate; no API keys are exposed in client code.

### Testing
- Ran `npm run build`, which completed successfully and produced an optimized Next.js production build.
- The build included linting/type checks and generated static/dynamic pages without errors.
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f489651ebc8323943b24fa3381025c)