### PR TITLE
M1-BETA: add header-photo guidance and beta validation checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,23 @@ Expected JSON body:
 ```
 
 The route appends the report below the email draft and sends the message using Resend from the server side.
+
+
+## Header photo guidance (beta)
+
+For best extraction quality during beta:
+
+- Use the rear camera when possible.
+- Fill the frame with the printed work order header.
+- Keep text level, in focus, and free of glare/shadows.
+- Ensure this header block is visible: Work Order, Part Number, Revision, Customer, Quantity.
+- Capture the operation/process line in the same photo or a second support image.
+
+## Beta validation checklist
+
+Before generating the Engineering draft, validate:
+
+- Header fields extracted by AI Vision/OCR match the printed work order.
+- Operation/process values are confirmed against the document.
+- Issue summary and requested correction are complete and specific.
+- Confirmation checkboxes are completed before send remains enabled.

--- a/app/globals.css
+++ b/app/globals.css
@@ -506,6 +506,19 @@ button:disabled { opacity: 0.45; }
   font-size: 13px;
 }
 
+
+.beta-checklist {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.beta-checklist li + li {
+  margin-top: 6px;
+}
+
 .quick-entry-grid {
   display: grid;
   grid-template-columns: 1fr;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -786,7 +786,19 @@ ${emailBody}`;
           <p>Step 1</p>
           <h2>Capture Work Order</h2>
         </div>
-        <p className="mini-note">Photo is saved as evidence. To auto-fill fields, paste copied/OCR text here or enter fields manually.</p>
+        <p className="mini-note">Photo is saved as evidence. To auto-fill fields, capture the full printed header (WO, part, revision, customer, quantity) in one clear shot, then run AI Vision or OCR.</p>
+        <div className="mini-note" role="note">
+          <strong>Header photo guidance (beta):</strong> Use rear camera, fill frame with the printed header, avoid glare/shadows, and keep text horizontal and in focus.
+        </div>
+        <div className="quick-entry-card">
+          <h3>Beta Validation Checklist</h3>
+          <p>Before you generate a draft, verify these beta checks to reduce extraction errors:</p>
+          <ul className="beta-checklist">
+            <li>Header photo includes Work Order, Part Number, Revision, Customer, and Quantity.</li>
+            <li>Operation/Process line is visible in the same image or a second support image.</li>
+            <li>Extracted fields match printed values before confirmation checkboxes are completed.</li>
+          </ul>
+        </div>
         <input
           ref={takePhotoInputRef}
           className="capture-input-hidden"


### PR DESCRIPTION
### Motivation

- Reduce AI Vision/OCR extraction errors by guiding users to capture a complete, clear printed header in a single image.  
- Provide an explicit pre-draft validation step for beta so users verify extracted header and process values before sending.  
- Surface lightweight in-app guidance to improve data quality without changing extraction logic.

### Description

- Added header-photo guidance copy to the Capture Work Order panel to instruct users to capture the full printed header and to run AI Vision or OCR afterward (`app/page.tsx`).  
- Added an in-app Beta Validation Checklist card with three pre-draft checks (header coverage, operation/process visibility, and extracted-value verification) (`app/page.tsx`).  
- Introduced styling for the checklist via a new `.beta-checklist` rule in `app/globals.css`.  
- Updated `README.md` with a `Header photo guidance (beta)` section and a `Beta validation checklist` section describing the guidance and checks for the beta workflow.

### Testing

- Ran a production build with `npm run build`, which completed successfully (Next.js build, type checking, and static generation passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49071f38c8323b955c6af7b901fab)