### PR TITLE
Clean up bottom nav after focused task view change

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -92,7 +92,6 @@ const workflow: [string, string, string, TaskView][] = [
 const navItems: [string, TaskView][] = [
   ['⌂', 'Home'],
   ['📷', 'Capture'],
-  ['🧩', 'Build Correction'],
   ['🗂', 'Drafts'],
   ['◷', 'History'],
   ['⚙', 'More'],
@@ -749,6 +748,7 @@ ${emailBody}`;
   const generateDraft = () => {
     setShowDraft(true);
     setChecks(Array(5).fill(false));
+    setActiveView('Drafts');
     setStatus(readyToDraft ? 'Draft generated. Confirm every checkbox before sending.' : 'Draft generated with missing fields. Fill bracketed items before confirming.');
   };
 
@@ -1011,6 +1011,9 @@ ${emailBody}`;
             Extract From Text
           </button>
           <button type="button" onClick={loadSample}>Load Sample</button>
+        </div>
+        <div className="button-row">
+          <button type="button" onClick={() => setActiveView('Build Correction')}>Continue to Build Correction</button>
         </div>
       </section>
       ) : null}


### PR DESCRIPTION
### Motivation
- The bottom navigation was displaying six items which caused wrapping and truncation on iPhone and made the UI crowded; the goal is to reduce the bottom dock to five items while keeping the "Build Correction" task accessible.

### Description
- Removed the `Build Correction` entry from the `navItems` array in `app/page.tsx` so the bottom nav shows only Home, Capture, Drafts, History, and More.
- Added a `Continue to Build Correction` button to the bottom of the Capture view in `app/page.tsx` to allow users to navigate into the Build Correction task flow from Capture.
- Updated the `generateDraft` handler in `app/page.tsx` to call `setActiveView('Drafts')` so generating a draft advances the focused flow to Drafts while preserving the Build Correction state and workflow cards.
- Changes are contained in `app/page.tsx` and keep the existing Build Correction view, Drafts empty-state button, workflow cards, AI Vision/OCR flows, confirmation gate, and send route intact; closes #59.

### Testing
- Ran `npm run build`, and the Next.js production build completed successfully and generated static pages. (pass)
- The build included type checking/linting as part of Next.js build and completed without errors. (pass)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a6b5249c8323a8a93dbf929a1f4e)