### PR TITLE
Polish mobile glass UI spacing and dock states

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './woc.css';
 import './responsive-polish.css';
 import './status-toast.css';
 import './mobile-ui-fixes.css';
+import './mobile-ui-tighten.css';
 
 export const metadata: Metadata = {
   title: 'REFAB Connect',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import './woc.css';
 import './responsive-polish.css';
 import './status-toast.css';
+import './mobile-ui-fixes.css';
 
 export const metadata: Metadata = {
   title: 'REFAB Connect',

--- a/app/mobile-ui-fixes.css
+++ b/app/mobile-ui-fixes.css
@@ -1,0 +1,317 @@
+/*
+  Mobile UI polish for REFAB Connect / AI-WOC.
+  Goal: fix the current iPhone screenshots without touching workflow logic.
+  Scope: safe-area spacing, compact glass dock, readable nav states, and cleaner mobile card rhythm.
+*/
+
+:root {
+  --dock-bg: rgba(7, 9, 13, 0.82);
+  --dock-glass: rgba(22, 25, 31, 0.78);
+  --dock-glass-active: rgba(111, 26, 32, 0.72);
+  --dock-border: rgba(232, 238, 246, 0.32);
+  --dock-muted: rgba(238, 242, 247, 0.74);
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: geometricPrecision;
+}
+
+/* Prevent the hero/header from sliding under the Dynamic Island / browser chrome. */
+.shell {
+  padding-top: max(18px, calc(env(safe-area-inset-top) + 16px));
+  padding-bottom: max(132px, calc(env(safe-area-inset-bottom) + 118px));
+}
+
+.top-card {
+  overflow: visible;
+  transform: translateZ(0);
+}
+
+.top-copy h1,
+.hero-card h2,
+.panel h2,
+.workflow-row h3,
+.stats-grid span,
+.stats-grid strong {
+  text-wrap: balance;
+}
+
+/* Keep the app header readable on narrow iPhones. */
+@media (max-width: 620px) {
+  .shell {
+    padding-top: max(48px, calc(env(safe-area-inset-top) + 14px));
+    padding-bottom: max(136px, calc(env(safe-area-inset-bottom) + 118px));
+  }
+
+  .top-card {
+    grid-template-columns: 78px minmax(0, 1fr);
+    gap: 12px;
+    align-items: center;
+    padding: 14px;
+    border-radius: 26px;
+  }
+
+  .brand-tile {
+    width: 78px;
+    height: 78px;
+    border-radius: 20px;
+  }
+
+  .top-copy {
+    min-width: 0;
+  }
+
+  .top-copy h1 {
+    font-size: clamp(34px, 9.4vw, 44px);
+    line-height: 0.96;
+    letter-spacing: -0.055em;
+  }
+
+  .top-copy span {
+    margin-top: 8px;
+    font-size: 15px;
+    line-height: 1.2;
+  }
+
+  .system-pill {
+    grid-column: 2;
+    justify-self: start;
+    margin-top: -2px;
+    padding-top: 0;
+    font-size: 12px;
+    letter-spacing: 0.16em;
+  }
+
+  .system-pill span {
+    width: 13px;
+    height: 13px;
+  }
+}
+
+@media (max-width: 390px) {
+  .shell {
+    padding-top: max(48px, calc(env(safe-area-inset-top) + 12px));
+  }
+
+  .top-card {
+    grid-template-columns: 70px minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .brand-tile {
+    width: 70px;
+    height: 70px;
+  }
+
+  .top-copy h1 {
+    font-size: 32px;
+  }
+
+  .top-copy span {
+    font-size: 13px;
+  }
+
+  .system-pill {
+    font-size: 10.5px;
+  }
+}
+
+/* The dock in the screenshots was drifting into large white buttons. Force premium dark glass states. */
+.bottom-nav {
+  overflow: visible;
+  gap: 5px;
+  padding: 7px;
+  border-color: rgba(216, 225, 235, 0.34);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(255, 255, 255, 0.16), transparent 26%),
+    radial-gradient(circle at 50% 100%, rgba(209, 50, 57, 0.2), transparent 42%),
+    linear-gradient(180deg, rgba(38, 42, 50, 0.88), rgba(7, 9, 13, 0.94));
+  box-shadow:
+    0 -10px 32px rgba(0, 0, 0, 0.54),
+    0 0 30px rgba(208, 48, 56, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.72);
+}
+
+.bottom-nav button,
+.bottom-nav a {
+  margin: 0;
+  min-width: 0;
+  min-height: 54px;
+  padding: 6px 3px 5px;
+  display: grid;
+  place-items: center;
+  gap: 2px;
+  border: 1px solid rgba(236, 241, 247, 0.2);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(31, 35, 42, 0.82) 30%, rgba(7, 9, 13, 0.9));
+  color: var(--dock-muted);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -10px 18px rgba(0, 0, 0, 0.28),
+    0 8px 18px rgba(0, 0, 0, 0.28);
+}
+
+.bottom-nav button.active,
+.bottom-nav a.active,
+.bottom-nav .active {
+  color: #ff6268;
+  border-color: rgba(247, 154, 158, 0.72);
+  background:
+    radial-gradient(circle at 50% 12%, rgba(255, 146, 151, 0.28), transparent 34%),
+    linear-gradient(180deg, rgba(121, 33, 41, 0.88), rgba(47, 25, 31, 0.86));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    inset 0 0 24px rgba(209, 50, 57, 0.24),
+    0 0 20px rgba(209, 50, 57, 0.34),
+    0 8px 20px rgba(0, 0, 0, 0.3);
+}
+
+.nav-icon,
+.bottom-nav .glass-icon-tile {
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  border-radius: 10px;
+  color: rgba(246, 249, 252, 0.92);
+}
+
+.nav-icon::before {
+  color: rgba(246, 249, 252, 0.92);
+  text-shadow: 0 0 10px rgba(246, 249, 252, 0.28);
+}
+
+.bottom-nav button.active .nav-icon,
+.bottom-nav a.active .nav-icon,
+.bottom-nav .active .nav-icon {
+  color: #ffdadd;
+  border-color: rgba(255, 160, 164, 0.9);
+  box-shadow:
+    0 0 16px rgba(209, 50, 57, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.bottom-nav button.active::after,
+.bottom-nav a.active::after,
+.bottom-nav .active::after {
+  width: 5px;
+  height: 5px;
+  margin-top: -1px;
+  border-radius: 999px;
+  background: #ff4a50;
+  box-shadow: 0 0 12px rgba(255, 74, 80, 0.85);
+}
+
+@media (max-width: 620px) {
+  .bottom-nav {
+    left: 12px;
+    right: 12px;
+    bottom: max(10px, calc(env(safe-area-inset-bottom) + 8px));
+    padding: 6px;
+    border-radius: 24px;
+  }
+
+  .bottom-nav button,
+  .bottom-nav a {
+    min-height: 52px;
+    border-radius: 17px;
+    font-size: 10px;
+  }
+
+  .nav-icon,
+  .bottom-nav .glass-icon-tile {
+    width: 26px;
+    height: 26px;
+    min-width: 26px;
+  }
+}
+
+/* Workflow cards should read like a guided list, not centered poster text. */
+.workflow-row {
+  min-height: 86px;
+  align-items: center;
+}
+
+.workflow-row > div {
+  min-width: 0;
+  text-align: left;
+}
+
+.workflow-row h3,
+.workflow-row p {
+  text-align: left;
+  text-wrap: balance;
+}
+
+.workflow-row h3 {
+  font-size: clamp(20px, 5vw, 28px);
+  line-height: 1.05;
+}
+
+.workflow-row p {
+  font-size: clamp(15px, 4vw, 19px);
+  line-height: 1.25;
+}
+
+.workflow-row b {
+  justify-self: end;
+}
+
+@media (max-width: 430px) {
+  .workflow-card,
+  .panel {
+    border-radius: 26px;
+  }
+
+  .workflow-row {
+    grid-template-columns: 58px minmax(0, 1fr) 24px;
+    gap: 12px;
+    padding: 12px;
+    border-radius: 20px;
+  }
+
+  .step-box {
+    width: 54px;
+    height: 54px;
+    border-radius: 17px;
+  }
+
+  .workflow-row h3 {
+    font-size: 20px;
+  }
+
+  .workflow-row p {
+    font-size: 15px;
+  }
+
+  .workflow-row b {
+    font-size: 34px;
+  }
+}
+
+/* Reduce dense form feel on Capture without changing the actual fields or logic. */
+.quick-entry-card,
+.vision-status-card,
+.beta-checklist,
+input,
+select,
+textarea {
+  border-color: rgba(226, 233, 240, 0.25);
+}
+
+input,
+select,
+textarea {
+  min-height: 48px;
+}
+
+.capture-trigger {
+  border-color: rgba(226, 233, 240, 0.34);
+}
+
+button:disabled {
+  opacity: 0.5;
+  filter: saturate(0.8);
+}

--- a/app/mobile-ui-tighten.css
+++ b/app/mobile-ui-tighten.css
@@ -1,0 +1,213 @@
+/*
+  Focused mobile tightening pass for REFAB Connect / AI-WOC.
+  Lane: UI/icon polish only. No workflow or behavior changes.
+*/
+
+/* Extra protection for iPhone browser chrome / Dynamic Island screenshots. */
+@media (max-width: 620px) {
+  .shell {
+    padding-top: max(62px, calc(env(safe-area-inset-top) + 26px));
+  }
+
+  .top-card {
+    margin-top: 0;
+  }
+}
+
+@media (display-mode: standalone) and (max-width: 620px) {
+  .shell {
+    padding-top: max(54px, calc(env(safe-area-inset-top) + 18px));
+  }
+}
+
+/* Keep the header premium but less oversized on phones. */
+@media (max-width: 430px) {
+  .top-card {
+    grid-template-columns: 72px minmax(0, 1fr);
+    min-height: 154px;
+  }
+
+  .brand-tile {
+    width: 72px;
+    height: 72px;
+  }
+
+  .top-copy h1 {
+    font-size: clamp(31px, 9vw, 39px);
+    line-height: 0.96;
+  }
+
+  .top-copy span {
+    font-size: 13px;
+  }
+
+  .system-pill {
+    font-size: 10.8px;
+    letter-spacing: 0.14em;
+  }
+}
+
+/* Tighten home cards without changing the information architecture. */
+@media (max-width: 620px) {
+  .hero-card {
+    padding: 20px;
+    border-radius: 26px;
+  }
+
+  .hero-card h2 {
+    font-size: clamp(37px, 10vw, 47px);
+    line-height: 1.03;
+  }
+
+  .hero-card p {
+    font-size: 16px;
+    line-height: 1.34;
+  }
+
+  .stats-grid {
+    gap: 12px;
+    margin: 14px 0;
+  }
+
+  .stat-card {
+    border-radius: 24px;
+    min-height: 116px;
+  }
+}
+
+/* Dock: readable labels, dark inactive state, compact premium feel. */
+.bottom-nav button:not(.active),
+.bottom-nav a:not(.active) {
+  color: rgba(244, 247, 251, 0.76);
+  background:
+    radial-gradient(circle at 50% 10%, rgba(255, 255, 255, 0.12), transparent 30%),
+    linear-gradient(180deg, rgba(28, 32, 39, 0.92), rgba(7, 9, 13, 0.96));
+}
+
+.bottom-nav button:not(.active) .nav-icon,
+.bottom-nav a:not(.active) .nav-icon {
+  opacity: 0.98;
+}
+
+@media (max-width: 620px) {
+  .bottom-nav {
+    width: auto;
+    max-width: 100%;
+  }
+
+  .bottom-nav button,
+  .bottom-nav a {
+    min-height: 50px;
+    padding-top: 5px;
+    padding-bottom: 4px;
+  }
+}
+
+/* Workflow list should feel like quick action rows. */
+@media (max-width: 620px) {
+  .workflow-card {
+    padding: 16px;
+  }
+
+  .section-title {
+    margin-bottom: 14px;
+  }
+
+  .workflow-row {
+    margin-top: 10px;
+    min-height: 80px;
+  }
+
+  .workflow-row h3 {
+    letter-spacing: -0.035em;
+  }
+
+  .workflow-row p {
+    color: rgba(226, 232, 239, 0.9);
+  }
+}
+
+/* Capture view: keep it guided, not heavy. */
+@media (max-width: 620px) {
+  .panel {
+    padding: 18px;
+    border-radius: 26px;
+  }
+
+  .panel h2 {
+    font-size: 32px;
+    line-height: 1.05;
+  }
+
+  .mini-note {
+    font-size: 14px;
+    line-height: 1.42;
+  }
+
+  .beta-checklist {
+    font-size: 13px;
+  }
+
+  .capture-trigger {
+    min-height: 76px;
+    border-radius: 20px;
+  }
+
+  .button-row {
+    gap: 10px;
+  }
+
+  .button-row button {
+    min-height: 58px;
+    line-height: 1.15;
+  }
+
+  .quick-entry-card {
+    padding: 14px;
+    border-radius: 20px;
+  }
+
+  .quick-entry-card h3 {
+    font-size: 22px;
+  }
+
+  label {
+    margin: 11px 0;
+  }
+
+  input,
+  select,
+  textarea {
+    min-height: 46px;
+    padding: 12px 14px;
+    border-radius: 15px;
+  }
+
+  .capture-panel textarea {
+    min-height: 104px;
+  }
+}
+
+/* Empty states should feel intentionally minimal. */
+.empty-state p,
+.compact-info p {
+  color: rgba(226, 232, 239, 0.88);
+}
+
+.empty-state button,
+.empty-state a,
+.panel button.secondary {
+  border-color: rgba(226, 233, 240, 0.32);
+}
+
+/* iPad should keep the glass system but not become a stretched phone. */
+@media (min-width: 768px) {
+  .top-card {
+    min-height: 174px;
+  }
+
+  .bottom-nav button,
+  .bottom-nav a {
+    min-height: 54px;
+  }
+}

--- a/docs/design-assets/refab-connect-ui-icon-source.md
+++ b/docs/design-assets/refab-connect-ui-icon-source.md
@@ -1,0 +1,397 @@
+# REFAB Connect / AI-WOC UI + Icon Source
+
+Owner: Christopher Hilton / Applied Intelligence  
+Project: REFAB Connect / AI-WOC  
+Purpose: Single source file for UI polish, icon usage, asset storage, and implementation guardrails.
+
+---
+
+## 1. Operating Intent
+
+AI-WOC is a lightweight work-order correction app for shop-floor use.
+
+It should feel like a fast mobile task tool, not a crowded ERP form.
+
+Core UX principle:
+
+> Fast, simple, guided, and hard to mess up.
+
+Primary workflow:
+
+```text
+Home
+→ Capture
+→ AI Vision / Verify Header
+→ Continue to Build Correction
+→ Correction Type / Issue Fields
+→ Generate Draft
+→ Drafts
+→ Confirm + Send
+→ Start New Correction
+```
+
+---
+
+## 2. Current UI Direction
+
+The app should use the newer REFAB Connect / Applied Intelligence visual direction:
+
+- dark premium shell
+- mobile-first layout
+- compact iPhone/PWA spacing
+- glass / translucent chrome mainly for navigation, app header, and key UI elements
+- red, black, silver/gray REFAB brand influence
+- clean rounded cards
+- compact bottom dock
+- minimal clutter
+- focused task views instead of one long page
+
+Design rule:
+
+> The app should feel like a focused mobile task flow, not one long scrolling website.
+
+---
+
+## 3. Current UI Problems To Fix / Avoid
+
+From current screenshots, prioritize these polish items:
+
+1. **Header safe area**  
+   Top card can sit too close to the iPhone Dynamic Island/browser UI. Keep enough safe-area top padding.
+
+2. **Bottom dock contrast**  
+   Inactive dock items were reading too white/bright. Keep inactive states dark glass and active states red-glass.
+
+3. **Workflow row readability**  
+   Workflow rows should read left-to-right quickly. Avoid centered paragraph text in workflow rows.
+
+4. **Dock size**  
+   Dock should stay compact and premium. It should not steal screen space.
+
+5. **Icon overuse**  
+   Icons support workflow. They should not decorate every field.
+
+6. **ERP creep**  
+   Do not reintroduce long dropdown lists or crowded all-in-one forms.
+
+---
+
+## 4. Navigation Model
+
+Bottom nav must stay at five items:
+
+```text
+Home
+Capture
+Drafts
+History
+More
+```
+
+Do **not** add Build Correction as a bottom-nav item.
+
+Build Correction is an internal workflow step reached from:
+
+- Home workflow card
+- Capture view: Continue to Build Correction
+- Drafts empty state: Build Correction button
+
+---
+
+## 5. Icon Asset Storage
+
+Store new icon assets here:
+
+```text
+public/assets/icons/refab-connect-glass/
+```
+
+Recommended source/archive location:
+
+```text
+docs/design-assets/icon-packs/refab-connect-glass-icons.zip
+```
+
+Recommended structure:
+
+```text
+public/
+  assets/
+    icons/
+      refab-connect-glass/
+        home.png
+        capture.png
+        drafts.png
+        history.png
+        more.png
+        work-order.png
+        ai-vision.png
+        correction.png
+        send.png
+        icon-manifest.json
+        1024/
+          home.png
+          capture.png
+          drafts.png
+          history.png
+          more.png
+          work-order.png
+          ai-vision.png
+          correction.png
+          send.png
+
+docs/
+  design-assets/
+    icon-packs/
+      refab-connect-glass-icons.zip
+```
+
+---
+
+## 6. Required Icon Names + Uses
+
+| File | Use |
+|---|---|
+| `home.png` | Bottom nav Home |
+| `capture.png` | Bottom nav Capture |
+| `drafts.png` | Bottom nav Drafts |
+| `history.png` | Bottom nav History |
+| `more.png` | Bottom nav More |
+| `work-order.png` | Capture router / work order workflow state |
+| `ai-vision.png` | Extract + Confirm / AI Vision state |
+| `correction.png` | Build Correction workflow state |
+| `send.png` | Confirm + Send / Ready to Send state |
+
+Preferred bottom-nav visual footprint:
+
+```text
+28px–34px
+```
+
+Labels must stay readable and must not wrap.
+
+---
+
+## 7. Icon Usage Rules
+
+Use icons for:
+
+- bottom nav
+- workflow cards
+- major task actions
+- capture / AI Vision / correction / send states
+
+Avoid icons for:
+
+- every field
+- every small label
+- dense form rows
+- decorative filler
+
+Icon style direction:
+
+- premium glass
+- simple shapes
+- recognizable at small size
+- works on dark background
+- consistent sizing
+- restrained glow
+- no visual clutter
+- no overly complex details that disappear at mobile size
+
+---
+
+## 8. Suggested React Mapping
+
+Use this when replacing emoji icons with image assets after approval.
+
+```ts
+const navIconMap: Record<string, string> = {
+  Home: '/assets/icons/refab-connect-glass/home.png',
+  Capture: '/assets/icons/refab-connect-glass/capture.png',
+  Drafts: '/assets/icons/refab-connect-glass/drafts.png',
+  History: '/assets/icons/refab-connect-glass/history.png',
+  More: '/assets/icons/refab-connect-glass/more.png',
+};
+
+const workflowIconMap: Record<string, string> = {
+  'Capture Router': '/assets/icons/refab-connect-glass/work-order.png',
+  'Extract + Confirm': '/assets/icons/refab-connect-glass/ai-vision.png',
+  'Build Correction': '/assets/icons/refab-connect-glass/correction.png',
+  'Confirm + Send': '/assets/icons/refab-connect-glass/send.png',
+};
+```
+
+Example nav render:
+
+```tsx
+<img
+  className="nav-icon-img"
+  src={navIconMap[label]}
+  alt=""
+  aria-hidden="true"
+/>
+```
+
+Example workflow render:
+
+```tsx
+<img
+  className="workflow-icon-img"
+  src={workflowIconMap[title]}
+  alt=""
+  aria-hidden="true"
+/>
+```
+
+Do not use these images as semantic content. Labels already provide the meaning.
+
+---
+
+## 9. Suggested CSS
+
+```css
+.nav-icon-img {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+  display: block;
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.12));
+}
+
+.workflow-icon-img {
+  width: 54px;
+  height: 54px;
+  object-fit: contain;
+  display: block;
+}
+
+.bottom-nav button,
+.bottom-nav a {
+  color: rgba(238, 242, 247, 0.74);
+}
+
+.bottom-nav button.active,
+.bottom-nav a.active,
+.bottom-nav .active {
+  color: #ff6268;
+}
+```
+
+Keep icon containers compact. Do not enlarge the dock to fit the artwork.
+
+---
+
+## 10. Current Working Features To Preserve
+
+Do not break these while changing UI/icons:
+
+- AI Vision extraction
+- Basic OCR fallback
+- uploaded image preview
+- Quick Entry/header fields
+- focused task views
+- simplified correction type flow
+- Generate Draft
+- confirmation checkboxes
+- Send Email
+- History
+- Start New Correction / Clear Form
+- Vercel environment variable usage
+- server-side `OPENAI_API_KEY` only
+
+---
+
+## 11. Correction Type Scope
+
+Keep correction entry simple.
+
+Correction Type options:
+
+- Incorrect Time / Rate
+- Missing Grind / Finish Operation
+- Missing Weld Operation
+- Missing Fixture / Work Instruction
+- Wrong / Missing Router Step
+- Other
+
+Do not reintroduce a long ERP-style list of options.
+
+Core principle:
+
+> Pick correction type, enter one or two values, review, send.
+
+---
+
+## 12. AI Vision Behavior
+
+AI Vision is used to read the router/header photo.
+
+Important extracted fields:
+
+- Work Order
+- Part Number
+- Revision
+- Customer
+- Quantity
+
+Best photo:
+
+```text
+Close, clear shot of the printed header.
+```
+
+Core rule:
+
+> Header photo = extraction. Full router photo = evidence/reference.
+
+---
+
+## 13. Do Not Add During UI/Icon Work
+
+Do not add:
+
+- database/storage
+- dashboard
+- barcode scanning
+- ERP updates
+- AI-CIS logic
+- LIR logic
+- ROI logic
+- case study logic
+- new workflow agents
+- extra app sections unless explicitly requested
+
+Focus on polishing the existing flow.
+
+---
+
+## 14. UI Polish Priority Order
+
+1. Preserve focused task view flow
+2. Keep bottom dock compact
+3. Make Capture → Build Correction → Drafts obvious
+4. Make icons consistent and premium
+5. Reduce field clutter
+6. Improve one-page email output
+7. Only then consider deeper visual/icon swaps
+
+---
+
+## 15. Implementation Rule
+
+Do not auto-replace production icons unless Chris approves the swap.
+
+Safe first step:
+
+```text
+Add assets → add source file → add CSS support → preview → approve → swap icons
+```
+
+---
+
+## 16. Core Principle
+
+> Standardize to Optimize.  
+> Make the correct action obvious.  
+> Make the wrong action hard to do.

--- a/docs/design-assets/refab-connect-ui-polish-concept-v2.md
+++ b/docs/design-assets/refab-connect-ui-polish-concept-v2.md
@@ -1,0 +1,552 @@
+# REFAB Connect / AI-WOC UI Polish Concept V2
+
+Owner: Christopher Hilton / Applied Intelligence  
+Project: REFAB Connect / AI-WOC  
+Lane: UI / Icon Polish Only  
+Status: Prepared ahead for future implementation  
+
+---
+
+## 1. Purpose
+
+This document captures the approved visual direction for a future UI polish pass.
+
+The goal is to make AI-WOC feel more premium, mobile-native, and focused without changing the workflow or app behavior.
+
+Core rule:
+
+> Polish the interface. Preserve the machine.
+
+---
+
+## 2. Non-Negotiable Guardrails
+
+Stay in the UI/icon polish lane only.
+
+Do **not** add:
+
+- workflow redesign
+- new features
+- dashboards
+- database/storage
+- barcode scanning
+- ERP updates
+- AI-CIS logic
+- LIR logic
+- ROI logic
+- case study logic
+- new agents
+- extra bottom nav items
+
+Preserve:
+
+- current beta flow
+- current app behavior
+- AI Vision extraction
+- Basic OCR fallback
+- uploaded image preview
+- Quick Entry/header fields
+- focused task views
+- simplified correction type flow
+- Generate Draft
+- confirmation checkboxes
+- Send Email
+- History
+- Start New Correction / Clear Form
+- server-side `OPENAI_API_KEY` behavior
+
+---
+
+## 3. Approved Design Direction
+
+The approved concept direction is:
+
+> Dark. Focused. Fast.  
+> Standardize to Optimize.
+
+The UI should feel:
+
+- premium
+- compact
+- mobile-first
+- industrial
+- dark glass / chrome
+- REFAB red + black + silver
+- guided
+- practical for shop-floor use
+
+It should **not** feel:
+
+- bloated
+- ERP-like
+- white-button heavy
+- generic SaaS
+- decorative for no reason
+- one long scrolling website
+
+---
+
+## 4. Main Concept Changes
+
+### A. Header / Top Card
+
+Current issue:
+
+- Header can crowd iPhone safe area / Dynamic Island.
+- Header is visually strong but needs tighter mobile scaling.
+
+Future polish:
+
+- Keep REFAB Connect logo tile on the left.
+- Keep `Work Order Correction` large and bold.
+- Keep `Powered by Applied Intelligence Framework` in red.
+- Keep `AI-WOC SYSTEM` with green status dot.
+- Add better safe-area top spacing.
+- Scale headline down slightly on narrow iPhones.
+
+Do not change the header meaning or structure.
+
+---
+
+### B. Home Composition
+
+Current issue:
+
+- Home is close, but can feel slightly oversized on phone.
+
+Future polish:
+
+- Keep the hero statement:
+
+```text
+Fix bad router data before it becomes waste.
+```
+
+- Tighten hero card padding.
+- Keep stats cards below.
+- Keep the workflow section visible and obvious.
+- Avoid making the home page feel like a website landing page.
+
+Goal:
+
+> A welder opens the app and instantly knows where to tap.
+
+---
+
+### C. Workflow Cards
+
+Use the concept style:
+
+```text
+[glass icon]  Capture Router       >
+              Snap or upload work order.
+
+[glass icon]  Extract + Confirm    >
+              Pull WO, part, process, and rate into clean fields.
+
+[glass icon]  Build Correction     >
+              Generate report and Engineering email draft.
+
+[glass icon]  Confirm + Send       >
+              Draft first. Confirm accuracy. Then send.
+```
+
+Rules:
+
+- Left-align text.
+- Keep rows compact.
+- Keep chevron on the right.
+- Do not center workflow row text.
+- Use workflow icons only here and on major task actions.
+- Do not add extra steps.
+
+---
+
+### D. Bottom Dock
+
+Bottom nav stays five items:
+
+```text
+Home
+Capture
+Drafts
+History
+More
+```
+
+Future polish:
+
+- Dock should be compact dark glass.
+- Inactive items should be dark, not white.
+- Active item should be red glass.
+- Keep labels readable.
+- Keep icons around 28px–34px visual footprint.
+- Keep active dot.
+
+Do not add Build Correction to the dock.
+
+---
+
+### E. Icon Lane
+
+Use the prepared icon source path:
+
+```text
+public/assets/icons/refab-connect-glass/
+```
+
+Required icons:
+
+```text
+home.png
+capture.png
+drafts.png
+history.png
+more.png
+work-order.png
+ai-vision.png
+correction.png
+send.png
+```
+
+Use icons for:
+
+- bottom nav
+- workflow cards
+- major task actions
+- capture / AI Vision / correction / send states
+
+Avoid icons for:
+
+- every field
+- every small label
+- dense form rows
+- decorative filler
+
+---
+
+## 5. Screen Concepts
+
+### Home — Concept
+
+Intent:
+
+- Clear app identity.
+- Clear value statement.
+- Clear current status cards.
+- Clear correction workflow.
+
+Structure:
+
+```text
+Top Card
+Hero Card
+Stats Cards
+Correction Workflow
+Bottom Dock
+```
+
+Acceptance check:
+
+- User can identify Capture Router within 2 seconds.
+- Bottom dock does not cover critical content.
+- Header does not sit under iPhone chrome.
+
+---
+
+### Capture — Concept
+
+Intent:
+
+- Guide user through header photo capture.
+- Avoid dense form feel.
+- Keep AI Vision and OCR obvious.
+
+Structure:
+
+```text
+Step Header
+Short instruction
+Beta guidance / checklist
+Take Photo
+Upload File / Picture
+Extract With AI Vision
+Basic OCR Fallback
+Quick Entry
+Bottom Dock
+```
+
+Future polish:
+
+- Make Take Photo and Upload File feel like major action cards.
+- Keep AI Vision visually recommended when image is available.
+- Keep OCR fallback secondary.
+- Do not remove manual entry.
+
+---
+
+### Build Correction — Concept
+
+Intent:
+
+- Focused issue entry.
+- No ERP-style complexity.
+
+Structure:
+
+```text
+Build Correction
+Correction Type
+Operation / Process
+What is Incorrect?
+Correct Value
+Notes Optional
+Generate Draft
+```
+
+Rules:
+
+- Keep correction types simple.
+- Do not add long dropdowns.
+- Generate Draft remains the primary action.
+
+---
+
+### Drafts — Concept
+
+Intent:
+
+- Empty state should feel intentional, not unfinished.
+
+Structure when empty:
+
+```text
+Drafts
+No active drafts
+Complete issue fields and generate correction report...
+Build Correction button
+```
+
+Structure when draft exists:
+
+```text
+Email Draft
+Report Preview
+Confirmation Checklist
+Send Email
+Copy Buttons
+```
+
+Rules:
+
+- Draft first.
+- Confirm accuracy.
+- Then send.
+
+---
+
+### History — Concept
+
+Intent:
+
+- Simple record of sent requests.
+- No dashboard.
+
+Rules:
+
+- Keep History minimal.
+- Do not add analytics or reporting.
+- No dashboard scope.
+
+---
+
+### More — Concept
+
+Intent:
+
+- Basic app/system info.
+- Default Engineering recipient.
+- No feature creep.
+
+Rules:
+
+- Keep it informational.
+- Do not turn More into settings/dashboard/admin.
+
+---
+
+## 6. Future React Implementation Notes
+
+When Chris approves icon swapping, use this mapping:
+
+```ts
+const navIconMap: Record<TaskView, string> = {
+  Home: '/assets/icons/refab-connect-glass/home.png',
+  Capture: '/assets/icons/refab-connect-glass/capture.png',
+  Drafts: '/assets/icons/refab-connect-glass/drafts.png',
+  History: '/assets/icons/refab-connect-glass/history.png',
+  More: '/assets/icons/refab-connect-glass/more.png',
+  'Build Correction': '/assets/icons/refab-connect-glass/correction.png',
+};
+
+const workflowIconMap: Record<string, string> = {
+  'Capture Router': '/assets/icons/refab-connect-glass/work-order.png',
+  'Extract + Confirm': '/assets/icons/refab-connect-glass/ai-vision.png',
+  'Build Correction': '/assets/icons/refab-connect-glass/correction.png',
+  'Confirm + Send': '/assets/icons/refab-connect-glass/send.png',
+};
+```
+
+If `TaskView` includes `Build Correction`, do not use it as a bottom-nav item. The mapping can exist for internal workflow use only.
+
+Example nav image:
+
+```tsx
+<img
+  className="nav-icon-img"
+  src={navIconMap[label]}
+  alt=""
+  aria-hidden="true"
+/>
+```
+
+Example workflow image:
+
+```tsx
+<img
+  className="workflow-icon-img"
+  src={workflowIconMap[title]}
+  alt=""
+  aria-hidden="true"
+/>
+```
+
+---
+
+## 7. Future CSS Starter
+
+Use only after assets are in place and icon swap is approved.
+
+```css
+.nav-icon-img {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+  display: block;
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.12));
+}
+
+.workflow-icon-img {
+  width: 54px;
+  height: 54px;
+  object-fit: contain;
+  display: block;
+}
+
+.workflow-row > div {
+  text-align: left;
+}
+
+.workflow-row h3,
+.workflow-row p {
+  text-align: left;
+}
+```
+
+---
+
+## 8. Implementation Phases
+
+### Phase 1 — CSS polish only
+
+Already started in PR #64.
+
+Scope:
+
+- top safe-area
+- compact dark dock states
+- workflow row readability
+- mobile card tightening
+
+No behavior changes.
+
+---
+
+### Phase 2 — Asset storage
+
+Add final icon assets to:
+
+```text
+public/assets/icons/refab-connect-glass/
+```
+
+Add archive to:
+
+```text
+docs/design-assets/icon-packs/refab-connect-glass-icons.zip
+```
+
+Do not swap production icons yet.
+
+---
+
+### Phase 3 — Icon swap
+
+Only after approval:
+
+- replace emoji/icon placeholders with PNG images
+- keep labels
+- keep five bottom nav items
+- keep workflow rows unchanged structurally
+
+---
+
+### Phase 4 — Final mobile pass
+
+Check on:
+
+- iPhone Safari
+- iPhone PWA/home screen mode
+- iPad Safari
+- desktop preview
+
+Acceptance checks:
+
+- header does not overlap Dynamic Island/browser chrome
+- dock stays compact
+- inactive dock states are dark glass
+- active dock state is red glass
+- workflow cards are readable
+- Capture flow is obvious
+- Drafts empty state feels intentional
+- app behavior unchanged
+
+---
+
+## 9. Final Approval Standard
+
+The finished UI should feel like:
+
+> A premium shop-floor correction tool built from the floor up.
+
+It should make the user feel:
+
+- guided
+- confident
+- fast
+- protected from mistakes
+
+It should not make the user feel:
+
+- buried in forms
+- lost in ERP options
+- forced into a dashboard
+- unsure what to tap next
+
+---
+
+## 10. Core Principle
+
+> Standardize to Optimize.  
+> Make the correct action obvious.  
+> Make the wrong action hard to do.


### PR DESCRIPTION
## Summary

- Adds a mobile-only UI polish override stylesheet for REFAB Connect / AI-WOC.
- Improves iPhone safe-area spacing so the header is less likely to sit under the Dynamic Island/browser chrome.
- Forces the bottom dock back into a compact dark-glass treatment instead of large bright inactive tiles.
- Left-aligns workflow card text for faster scanning and better shop-floor readability.
- Tightens mobile workflow/card/form rhythm without touching AI Vision, OCR, draft generation, send email, history, or app logic.

## Guardrails followed

- Keeps the five bottom-nav model: Home, Capture, Drafts, History, More.
- Does not add database, dashboard, barcode scanning, AI-CIS, ROI, LIR, or extra agent scope.
- No behavior changes; CSS-only UI polish plus stylesheet import.

## Files changed

- `app/mobile-ui-fixes.css`
- `app/layout.tsx`

## Notes

This is intended to address the current screenshots where the header is cramped under iPhone chrome/dynamic island and the dock inactive buttons are reading too bright/white.