### PR TITLE
Redesign Home screen to reflect AI-WOC system identity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -748,3 +748,49 @@ pre {
   .bottom-nav button { font-size: 11px; }
   .nav-icon { font-size: 19px; }
 }
+
+.home-system-hero {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  text-align: center;
+  gap: 22px;
+  min-height: unset;
+  padding: 34px 24px;
+  margin-top: 22px;
+}
+
+.home-system-icon {
+  width: clamp(104px, 32vw, 156px);
+  height: auto;
+  border-radius: 24px;
+  border: 1px solid rgba(212, 219, 226, 0.42);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.34);
+}
+
+.home-system-copy h2 {
+  margin: 0;
+  font-size: clamp(34px, 8.8vw, 52px);
+}
+
+.home-system-copy p {
+  margin-top: 12px;
+  font-size: clamp(19px, 4.8vw, 24px);
+  letter-spacing: 0.04em;
+}
+
+.home-workflow {
+  margin-top: 18px;
+  padding-top: 20px;
+}
+
+.section-title.centered {
+  justify-content: center;
+}
+
+.home-workflow-row {
+  align-items: center;
+}
+
+.home-workflow-row h3 {
+  margin: 0;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -819,36 +819,24 @@ ${emailBody}`;
 
       {activeView === 'Home' ? (
       <>
-      <section className="hero-card glow-card">
-        <div className="hero-copy">
-          <p className="eyebrow">Standardize to Optimize</p>
-          <h2>Fix bad router data before it becomes waste.</h2>
-          <p>Snap the work order, confirm the WO, part, process, and issue, then generate a controlled Engineering correction request.</p>
-        </div>
-        <div className="hero-emblem" aria-hidden="true">
-          <div className="shield">✓</div>
-          <div className="rings" />
+      <section className="hero-card glow-card home-system-hero">
+        <img className="home-system-icon" src="/refab-connect-master-1024.png" alt="Refab Connect AI-WOC" />
+        <div className="hero-copy home-system-copy">
+          <h2>AI-WOC System Active</h2>
+          <p>Clear. Guided. Fast.</p>
         </div>
       </section>
 
-      <section className="stats-grid" aria-label="AI-WOC stats">
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile">🗂</div><div><span>Draft Requests</span><strong>{showDraft ? '1' : '0'}</strong><small>Current session</small></div></article>
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile active">➤</div><div><span>Ready to Send</span><strong>{allConfirmed ? '1' : '0'}</strong><small>Confirmed gate</small></div></article>
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile">◷</div><div><span>Sent Today</span><strong>{history.length}</strong><small>Session count</small></div></article>
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile">ID</div><div><span>Mode</span><strong>WOC</strong><small>Correction flow</small></div></article>
-      </section>
-
-      <section className="workflow-card compact-card glow-card">
-        <div className="section-title">
+      <section className="workflow-card compact-card glow-card home-workflow" aria-label="AI-WOC workflow steps">
+        <div className="section-title centered">
           <span />
-          <h2>Correction Workflow</h2>
+          <h2>Workflow</h2>
         </div>
-        {workflow.map(([step, title, subtitle, targetView]) => (
-          <button type="button" className="workflow-row" key={title} onClick={() => setActiveView(targetView)}>
-            <div className="step-box glass-icon-tile">{step}</div>
+        {workflow.map(([step, title, _subtitle, targetView], index) => (
+          <button type="button" className="workflow-row home-workflow-row" key={title} onClick={() => setActiveView(targetView)}>
+            <div className="step-box glass-icon-tile">{index + 1}</div>
             <div>
               <h3>{title}</h3>
-              <p>{subtitle}</p>
             </div>
             <b>›</b>
           </button>


### PR DESCRIPTION
### Motivation
- Create a clean, centered system-style Home screen that communicates the Refab Connect / AI-WOC workflow while keeping all existing functionality intact.
- Reduce visual clutter on the Home view and make the primary workflow immediately visible and mobile-first.

### Description
- Replaced the previous hero and stats layout in `app/page.tsx` with a centered hero that uses `public/refab-connect-master-1024.png` and text set to `AI-WOC System Active` and `Clear. Guided. Fast.`.
- Removed the Home stats grid and simplified the Home workflow presentation to four visible steps while preserving the existing `setActiveView(targetView)` navigation behavior for each row.
- Updated the workflow rows to use numeric step badges and removed subtitle text from the condensed Home presentation to emphasize clarity.
- Added new styling in `app/globals.css` for `.home-system-hero`, `.home-system-icon`, `.home-system-copy`, `.home-workflow`, `.section-title.centered`, and `.home-workflow-row` to support centered, mobile-first spacing and vertical rhythm.

### Testing
- Ran `npm run lint`, which could not complete due to an interactive Next.js ESLint setup prompt in this environment (lint did not finish).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66c5b2f308323ad4015be9d9a24e0)