### PR TITLE
Refine Home screen to minimal Option 3 layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -135,6 +135,76 @@ body {
   box-shadow: 0 0 18px rgba(34, 223, 146, 0.8);
 }
 
+.home-minimal {
+  margin-top: 18px;
+  padding: 28px 20px;
+  border-radius: 30px;
+  display: grid;
+  justify-items: center;
+  text-align: center;
+  gap: 18px;
+}
+
+.home-minimal-brand {
+  width: 92px;
+  height: 92px;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(133, 202, 255, 0.5);
+}
+
+.home-minimal-brand img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.home-minimal-copy h1 {
+  margin: 0;
+  font-size: clamp(34px, 8.2vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.home-minimal-copy p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 19px;
+  font-weight: 600;
+}
+
+.workflow-minimal {
+  width: min(520px, 100%);
+  text-align: left;
+}
+
+.workflow-minimal h2 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blue);
+}
+
+.workflow-minimal ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid rgba(202, 209, 217, 0.24);
+}
+
+.workflow-minimal li {
+  padding: 12px 2px;
+  border-bottom: 1px solid rgba(202, 209, 217, 0.24);
+  font-weight: 700;
+  color: var(--text);
+}
+
+.home-minimal-cta button {
+  min-width: 220px;
+}
+
 .hero-card {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 230px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,13 +82,6 @@ const confirmationLabels = [
 
 type TaskView = 'Home' | 'Capture' | 'Build Correction' | 'Drafts' | 'History' | 'More';
 
-const workflow: [string, string, string, TaskView][] = [
-  ['📷', 'Capture Router', 'Snap or upload work order.', 'Capture'],
-  ['📋', 'Extract + Confirm', 'Pull WO, part, process, and rate into clean fields.', 'Capture'],
-  ['🗂', 'Build Correction', 'Generate report and Engineering email draft.', 'Build Correction'],
-  ['➤', 'Confirm + Send', 'Draft first. Confirm accuracy. Then send.', 'Drafts'],
-];
-
 const navItems: [string, TaskView][] = [
   ['⌂', 'Home'],
   ['📷', 'Capture'],
@@ -806,53 +799,29 @@ ${emailBody}`;
 
   return (
     <main className="shell" id="home">
-      <section className="top-card glow-card">
-        <div className="brand-tile" aria-label="REFAB Connect icon">
-          <img src="/apple-touch-icon.png" alt="REFAB Connect" />
-        </div>
-        <div className="top-copy">
-          <h1>Work Order<br />Correction</h1>
-          <span>Powered by Applied Intelligence Framework</span>
-        </div>
-        <div className="system-pill"><span />AI-WOC SYSTEM</div>
-      </section>
-
       {activeView === 'Home' ? (
       <>
-      <section className="hero-card glow-card">
-        <div className="hero-copy">
-          <p className="eyebrow">Standardize to Optimize</p>
-          <h2>Fix bad router data before it becomes waste.</h2>
-          <p>Snap the work order, confirm the WO, part, process, and issue, then generate a controlled Engineering correction request.</p>
+      <section className="home-minimal glow-card">
+        <div className="system-pill"><span />SYSTEM ACTIVE</div>
+        <div className="home-minimal-brand" aria-label="REFAB Connect icon">
+          <img src="/apple-touch-icon.png" alt="REFAB Connect" />
         </div>
-        <div className="hero-emblem" aria-hidden="true">
-          <div className="shield">✓</div>
-          <div className="rings" />
+        <div className="home-minimal-copy">
+          <h1>AI-WOC System Active</h1>
+          <p>Clear. Guided. Fast.</p>
         </div>
-      </section>
-
-      <section className="stats-grid" aria-label="AI-WOC stats">
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile">🗂</div><div><span>Draft Requests</span><strong>{showDraft ? '1' : '0'}</strong><small>Current session</small></div></article>
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile active">➤</div><div><span>Ready to Send</span><strong>{allConfirmed ? '1' : '0'}</strong><small>Confirmed gate</small></div></article>
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile">◷</div><div><span>Sent Today</span><strong>{history.length}</strong><small>Session count</small></div></article>
-        <article className="stat-card glow-card"><div className="stat-icon glass-icon-tile">ID</div><div><span>Mode</span><strong>WOC</strong><small>Correction flow</small></div></article>
-      </section>
-
-      <section className="workflow-card compact-card glow-card">
-        <div className="section-title">
-          <span />
+        <section className="workflow-minimal" aria-label="Correction workflow steps">
           <h2>Correction Workflow</h2>
+          <ul>
+            <li>Capture Router</li>
+            <li>Extract + Confirm</li>
+            <li>Build Correction</li>
+            <li>Confirm + Send</li>
+          </ul>
+        </section>
+        <div className="home-minimal-cta">
+          <button type="button" onClick={() => setActiveView('Capture')}>Start Capture</button>
         </div>
-        {workflow.map(([step, title, subtitle, targetView]) => (
-          <button type="button" className="workflow-row" key={title} onClick={() => setActiveView(targetView)}>
-            <div className="step-box glass-icon-tile">{step}</div>
-            <div>
-              <h3>{title}</h3>
-              <p>{subtitle}</p>
-            </div>
-            <b>›</b>
-          </button>
-        ))}
       </section>
 
       </>


### PR DESCRIPTION
### Motivation
- Reduce visual clutter on the Home screen and provide a calm, system-focused entry point following the Option 3 direction. 
- Surface a clear primary action so users can immediately begin the capture workflow without distraction. 

### Description
- Replace the previous top-card / hero / stats / workflow composition with a single `home-minimal` panel that centers a system status badge and brand icon. 
- Update the system badge text to `SYSTEM ACTIVE`, add centered brand tile, and change title/subtext to `AI-WOC System Active` and `Clear. Guided. Fast.`. 
- Replace card-heavy workflow rows with a minimal `workflow-minimal` list of steps (Capture Router, Extract + Confirm, Build Correction, Confirm + Send) and add a primary `Start Capture` button that uses `setActiveView('Capture')`. 
- Add supporting styles in `app/globals.css` for `.home-minimal`, `.home-minimal-brand`, `.home-minimal-copy`, `.workflow-minimal`, and `.home-minimal-cta`, and remove the previous `workflow` constant usage from the Home render. 

### Testing
- Ran `npm run lint`, which could not complete non-interactively because ESLint prompted for initial configuration (lint did not finish successfully). 
- No automated unit or end-to-end tests were present or executed as part of this change. 
- Static inspection of updated files (`app/page.tsx`, `app/globals.css`) confirms the UI-only changes and that navigation still uses `setActiveView` for the primary CTA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66f079c28832392bdbfb5236bdeb4)