### PR TITLE
Refine Home screen to minimal Option 3 layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -753,10 +753,24 @@ pre {
   grid-template-columns: 1fr;
   justify-items: center;
   text-align: center;
-  gap: 22px;
+  gap: 18px;
   min-height: unset;
-  padding: 34px 24px;
+  padding: 28px 24px;
   margin-top: 22px;
+}
+
+.home-active-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(164, 239, 212, 0.55);
+  background: rgba(68, 197, 145, 0.15);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: #d9f9ec;
 }
 
 .home-system-icon {
@@ -789,8 +803,14 @@ pre {
 
 .home-workflow-row {
   align-items: center;
+  pointer-events: none;
 }
 
 .home-workflow-row h3 {
   margin: 0;
+}
+
+.home-start-button {
+  width: min(360px, 100%);
+  margin-top: 4px;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -820,11 +820,19 @@ ${emailBody}`;
       {activeView === 'Home' ? (
       <>
       <section className="hero-card glow-card home-system-hero">
+        <div className="home-active-badge">SYSTEM ACTIVE</div>
         <img className="home-system-icon" src="/refab-connect-master-1024.png" alt="Refab Connect AI-WOC" />
         <div className="hero-copy home-system-copy">
           <h2>AI-WOC System Active</h2>
           <p>Clear. Guided. Fast.</p>
         </div>
+        <button type="button" className="capture-trigger home-start-button" onClick={() => setActiveView('Capture')}>
+          <span className="glass-icon-tile active">📷</span>
+          <span>
+            <strong>Start Capture</strong>
+            <small>Begin work order intake.</small>
+          </span>
+        </button>
       </section>
 
       <section className="workflow-card compact-card glow-card home-workflow" aria-label="AI-WOC workflow steps">
@@ -832,14 +840,13 @@ ${emailBody}`;
           <span />
           <h2>Workflow</h2>
         </div>
-        {workflow.map(([step, title, _subtitle, targetView], index) => (
-          <button type="button" className="workflow-row home-workflow-row" key={title} onClick={() => setActiveView(targetView)}>
+        {workflow.map(([_step, title], index) => (
+          <div className="workflow-row home-workflow-row" key={title}>
             <div className="step-box glass-icon-tile">{index + 1}</div>
             <div>
               <h3>{title}</h3>
             </div>
-            <b>›</b>
-          </button>
+          </div>
         ))}
       </section>
 


### PR DESCRIPTION
### Motivation
- Implement a minimal Option 3 Home screen that focuses the user on a single primary entry point while preserving the required system branding and messaging.

### Description
- Added a visible `SYSTEM ACTIVE` badge and tightened hero spacing in `app/page.tsx` and `app/globals.css` to match the Option 3 visual language.
- Centered the Refab icon and preserved the `AI-WOC System Active` and `Clear. Guided. Fast.` copy in the hero section by updating `app/page.tsx`.
- Added a single primary `Start Capture` CTA wired to `setActiveView('Capture')` and sized with `.home-start-button` in `app/globals.css` to provide the single entry action.
- Simplified the workflow list to non-interactive guidance rows (no change to workflow logic outside the Home entry button) and added supporting styles in `app/globals.css`.

### Testing
- Ran `npm run build` (Next.js production build) and the project compiled successfully with static pages generated, indicating the change is buildable and mergeable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67fa497a8832385b406eaaeea96bf)