### PR TITLE
Declutter Capture screen layout (UI-only, no logic changes)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -542,6 +542,24 @@ button:disabled { opacity: 0.45; }
   min-height: 86px;
 }
 
+.capture-intro {
+  margin-bottom: 10px;
+}
+
+.capture-guidance {
+  margin-top: 8px;
+}
+
+.capture-section {
+  margin-top: 14px;
+}
+
+.capture-section h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+  letter-spacing: 0.01em;
+}
+
 .quick-entry-full {
   grid-column: 1 / -1;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -859,13 +859,9 @@ ${emailBody}`;
           <p>Step 1</p>
           <h2>Capture Work Order</h2>
         </div>
-        <p className="mini-note">Photo is saved as evidence. To auto-fill fields, capture the full printed header (WO, part, revision, customer, quantity) in one clear shot, then run AI Vision or OCR.</p>
-        <div className="mini-note" role="note">
-          <strong>Header photo guidance (beta):</strong> Use rear camera, fill frame with the printed header, avoid glare/shadows, and keep text horizontal and in focus.
-        </div>
-        <div className="quick-entry-card">
-          <h3>Beta Validation Checklist</h3>
-          <p>Before you generate a draft, verify these beta checks to reduce extraction errors:</p>
+        <p className="mini-note capture-intro">Follow this flow: 1) Take Photo or Upload, 2) Preview, 3) Extract with AI Vision or OCR, 4) Quick Entry, 5) OCR text fallback.</p>
+        <div className="quick-entry-card capture-guidance" role="note">
+          <h3>Header Photo Guidance</h3>
           <ul className="beta-checklist">
             <li>Header photo includes Work Order, Part Number, Revision, Customer, and Quantity.</li>
             <li>Operation/Process line is visible in the same image or a second support image.</li>
@@ -891,22 +887,31 @@ ${emailBody}`;
             onWorkOrderFileSelected(event.target.files?.[0]);
           }}
         />
-        <button type="button" className="capture-trigger" onClick={() => takePhotoInputRef.current?.click()}>
+        <div className="capture-section">
+          <h3>1. Take Photo / Upload</h3>
+          <button type="button" className="capture-trigger" onClick={() => takePhotoInputRef.current?.click()}>
           <span className="glass-icon-tile active">📷</span>
           <span>
             <strong>Take Photo</strong>
             <small>Use rear camera to capture work order.</small>
           </span>
-        </button>
-        <button type="button" className="capture-trigger" onClick={() => uploadInputRef.current?.click()}>
+          </button>
+          <button type="button" className="capture-trigger" onClick={() => uploadInputRef.current?.click()}>
           <span className="glass-icon-tile">📁</span>
           <span>
             <strong>Upload File / Picture</strong>
             <small>Select image or PDF from Photo Library or Files.</small>
           </span>
-        </button>
-        {imageUrl ? <img className="preview" src={imageUrl} alt="Uploaded work order preview" /> : null}
-        <div className="button-row">
+          </button>
+        </div>
+        <div className="capture-section">
+          <h3>2. Preview</h3>
+          {imageUrl ? <img className="preview" src={imageUrl} alt="Uploaded work order preview" /> : <p className="mini-note">No image preview yet.</p>}
+          {!imageUrl && selectedFileName ? <p className="mini-note">Selected file: {selectedFileName}</p> : null}
+        </div>
+        <div className="capture-section">
+          <h3>3. Extract</h3>
+          <div className="button-row">
           <button
             type="button"
             className="secondary"
@@ -923,7 +928,7 @@ ${emailBody}`;
           >
             {ocrLoading ? 'Extracting Text…' : 'Basic OCR Fallback'}
           </button>
-        </div>
+          </div>
         {visionDebugMessage ? (
           <div className="vision-status-card" role="status" aria-live="polite">
             <p>{visionDebugMessage}</p>
@@ -939,10 +944,10 @@ ${emailBody}`;
             ) : null}
           </div>
         ) : null}
-        {!imageUrl && selectedFileName ? <p className="mini-note">Selected file: {selectedFileName}</p> : null}
-        <div className="quick-entry-card">
-          <h3>Quick Entry</h3>
-          <p>Enter the printed header and issue details while viewing the work order image.</p>
+        </div>
+        <div className="quick-entry-card capture-section">
+          <h3>4. Quick Entry</h3>
+          <p>Fill or correct extracted fields.</p>
           <div className="quick-entry-grid">
             <label>
               Work Order Number
@@ -993,6 +998,8 @@ ${emailBody}`;
             </label>
           </div>
         </div>
+        <div className="capture-section">
+        <h3>5. OCR Text Fallback</h3>
         <label>
           Paste Router / OCR Text
           <textarea
@@ -1006,6 +1013,7 @@ ${emailBody}`;
             Extract From Text
           </button>
           <button type="button" onClick={loadSample}>Load Sample</button>
+        </div>
         </div>
         <div className="button-row">
           <button type="button" onClick={() => setActiveView('Build Correction')}>Continue to Build Correction</button>


### PR DESCRIPTION
### Motivation
- Improve scanability and mobile readability of the Capture screen by arranging content to match the operator flow without changing behavior. 
- Reduce repeated helper copy and visual clutter so the most important actions are easier to find on small screens. 
- Preserve all existing extraction, OCR, upload, preview, Quick Entry, and send workflows while improving visual hierarchy.

### Description
- Reorganized the Capture panel markup into numbered `capture-section` groups that map to the flow: `1) Take Photo / Upload`, `2) Preview`, `3) Extract`, `4) Quick Entry`, `5) OCR Text Fallback` in `app/page.tsx`.
- Replaced multiple overlapping helper notes with a concise flow intro (`.capture-intro`) and a single guidance card (`.capture-guidance`) while keeping all buttons, handlers, and state wiring unchanged. 
- Added lightweight layout and spacing helpers in `app/globals.css`: `.capture-intro`, `.capture-guidance`, `.capture-section`, and `.capture-section h3` to improve spacing and visual hierarchy on phones.
- This change is UI-only and does not alter any extraction, OCR, report, email, or send logic.

### Testing
- Production build was run with `next build` and completed successfully. 
- `npm run lint` could not be completed non-interactively due to the interactive Next.js ESLint setup prompt in this environment. 
- Manual verification ensured existing capture/upload/preview/AI Vision/OCR/Quick Entry and text-extract buttons remain present and wired to the original handlers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6898dcca88323919ba276f9f4ccf1)