### PR TITLE
Optimize Home layout for iPad/tablet widths

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -732,6 +732,37 @@ pre {
   box-shadow: 0 10px 28px rgba(0,0,0,0.3);
 }
 
+
+@media (min-width: 768px) and (max-width: 1100px) {
+  #home {
+    max-width: 900px;
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  #home .top-card,
+  #home .home-system-hero,
+  #home .home-workflow {
+    width: min(100%, 680px);
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  #home .home-system-hero {
+    padding: 28px 30px;
+  }
+
+  #home .home-workflow {
+    padding: 20px 22px;
+  }
+
+  .bottom-nav {
+    max-width: 640px;
+    left: max(24px, calc((100vw - 640px) / 2));
+    right: max(24px, calc((100vw - 640px) / 2));
+  }
+}
+
 @media (max-width: 620px) {
   .shell { padding: 10px 14px 174px; }
   .top-card { grid-template-columns: auto 1fr; padding: 14px; gap: 12px; }


### PR DESCRIPTION
### Motivation
- Prevent the Home screen from stretching edge-to-edge on iPad/tablet widths while preserving the existing Option 3 layout and all app behavior.
- Center the Home content column and ensure workflow and hero cards remain readable and well-proportioned on tablet viewports.
- Keep changes strictly UI-only and avoid any logic or content modifications.

### Description
- Added a tablet-specific responsive block (`@media (min-width: 768px) and (max-width: 1100px)`) to `app/globals.css` to target iPad/tablet widths.
- Constrained and centered the Home container and primary cards by limiting `#home` and `.top-card`, `.home-system-hero`, `.home-workflow` to `width: min(100%, 680px)` and auto centering them.
- Tuned internal padding for `.home-system-hero` and `.home-workflow` to improve visual balance on tablets.
- Restricted the bottom dock (`.bottom-nav`) with a `max-width` and centered `left`/`right` offsets so the navigation remains appropriately sized and centered on tablet screens.

### Testing
- Attempted to run `npm run lint`, but the Next.js ESLint setup prompted for interactive configuration so linting did not complete in this non-interactive environment.
- No automated UI test suite was present for these styling changes, and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68c6ea7208323800ea0cd7fe2560c)