### PR TITLE
Build locked Refab Connect AI-WOC Home screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,9 +6,9 @@
   --panel-2: #1f232a;
   --line: rgba(212, 219, 226, 0.42);
   --line-soft: rgba(212, 219, 226, 0.22);
-  --blue: #d13239;
-  --blue-2: #f14a4f;
-  --soft-blue: #f2f4f7;
+  --blue: #4b8dff;
+  --blue-2: #6ea5ff;
+  --soft-blue: #eaf2ff;
   --green: #22df92;
   --text: #fcfcfd;
   --muted: #d2d8e0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -39,6 +39,13 @@ body {
   padding: 12px 14px 176px;
 }
 
+#home:has(.home-system-hero) {
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
 .glow-card {
   position: relative;
   isolation: isolate;
@@ -657,12 +664,12 @@ pre {
 
 .bottom-nav button.active {
   color: var(--blue-2);
-  background: linear-gradient(180deg, rgba(209,50,57,.34), rgba(70,74,82,.6));
+  background: linear-gradient(180deg, rgba(75,141,255,.3), rgba(70,74,82,.58));
   border: 1px solid rgba(232, 236, 241, 0.5);
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,.18),
-    inset 0 0 22px rgba(209,50,57,.16),
-    0 0 12px rgba(209,50,57,.28),
+    inset 0 0 22px rgba(75,141,255,.2),
+    0 0 12px rgba(75,141,255,.3),
     0 5px 14px rgba(0,0,0,.3);
 }
 
@@ -714,7 +721,7 @@ pre {
   height: 6px;
   border-radius: 999px;
   background: var(--blue-2);
-  box-shadow: 0 0 12px rgba(209,50,57,.8);
+  box-shadow: 0 0 12px rgba(75,141,255,.85);
 }
 
 .status {
@@ -802,10 +809,11 @@ pre {
   grid-template-columns: 1fr;
   justify-items: center;
   text-align: center;
-  gap: 18px;
+  gap: 20px;
   min-height: unset;
-  padding: 28px 24px;
-  margin-top: 22px;
+  padding: 30px 22px 24px;
+  margin-top: 10px;
+  border-radius: 34px;
 }
 
 .home-active-badge {
@@ -823,11 +831,11 @@ pre {
 }
 
 .home-system-icon {
-  width: clamp(104px, 32vw, 156px);
+  width: clamp(160px, 48vw, 232px);
   height: auto;
-  border-radius: 24px;
+  border-radius: 30px;
   border: 1px solid rgba(212, 219, 226, 0.42);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.34);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.4);
 }
 
 .home-system-copy h2 {
@@ -842,8 +850,9 @@ pre {
 }
 
 .home-workflow {
-  margin-top: 18px;
-  padding-top: 20px;
+  margin-top: 14px;
+  padding: 14px 16px 8px;
+  border-radius: 24px;
 }
 
 .section-title.centered {
@@ -853,6 +862,8 @@ pre {
 .home-workflow-row {
   align-items: center;
   pointer-events: none;
+  padding: 10px;
+  border-radius: 16px;
 }
 
 .home-workflow-row h3 {
@@ -860,6 +871,25 @@ pre {
 }
 
 .home-start-button {
-  width: min(360px, 100%);
-  margin-top: 4px;
+  width: min(420px, 100%);
+  margin-top: 2px;
+  min-height: 78px;
+  border-radius: 22px;
+  border: 1px solid rgba(173, 208, 255, 0.78);
+  background: linear-gradient(180deg, rgba(78, 146, 255, 0.92), rgba(49, 108, 210, 0.96));
+  box-shadow:
+    0 12px 30px rgba(55, 120, 230, 0.42),
+    inset 0 1px 0 rgba(255, 255, 255, 0.32);
+}
+
+.home-start-button .glass-icon-tile {
+  background: rgba(9, 26, 60, 0.35);
+  border-color: rgba(228, 238, 255, 0.78);
+  box-shadow: inset 0 0 16px rgba(180, 211, 255, 0.25);
+}
+
+.home-start-button strong {
+  font-size: 21px;
+  letter-spacing: 0.01em;
+  color: #f7fbff;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -43,7 +43,9 @@ body {
   min-height: 100svh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
+  padding-bottom: 248px;
+  scroll-padding-bottom: 248px;
 }
 
 .glow-card {
@@ -638,7 +640,7 @@ pre {
   padding: 6px 2px;
   min-height: 60px;
   border-radius: 18px;
-  color: var(--muted);
+  color: #8f98a5;
   font-size: 11px;
   font-weight: 1000;
   white-space: nowrap;
@@ -660,6 +662,9 @@ pre {
   min-width: 30px;
   border-radius: 9px;
   padding: 0;
+  border-color: rgba(154, 165, 181, 0.32);
+  background: linear-gradient(145deg, rgba(66, 73, 85, 0.28), rgba(14, 18, 24, 0.85));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .bottom-nav button.active {
@@ -671,6 +676,11 @@ pre {
     inset 0 0 22px rgba(75,141,255,.2),
     0 0 12px rgba(75,141,255,.3),
     0 5px 14px rgba(0,0,0,.3);
+}
+
+.bottom-nav button.active .glass-icon-tile {
+  border-color: rgba(204, 223, 255, 0.72);
+  background: linear-gradient(145deg, rgba(101, 162, 255, 0.34), rgba(20, 46, 90, 0.82));
 }
 
 .capture-input-hidden {
@@ -771,7 +781,7 @@ pre {
 }
 
 @media (max-width: 620px) {
-  .shell { padding: 10px 14px 174px; }
+  .shell { padding: 10px 14px 210px; }
   .top-card { grid-template-columns: auto 1fr; padding: 14px; gap: 12px; }
   .brand-tile { width: 82px; height: 82px; border-radius: 20px; }
   .system-pill { grid-column: 2; padding-top: 0; font-size: 12px; }
@@ -795,6 +805,10 @@ pre {
   .workflow-row p { font-size: 15px; }
   .bottom-nav { left: 14px; right: 14px; padding: 8px; gap: 4px; }
   .bottom-nav button { min-height: 58px; }
+  #home:has(.home-system-hero) {
+    padding-bottom: 268px;
+    scroll-padding-bottom: 268px;
+  }
 }
 
 @media (max-width: 390px) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -811,10 +811,10 @@ ${emailBody}`;
           <img src="/apple-touch-icon.png" alt="REFAB Connect" />
         </div>
         <div className="top-copy">
-          <h1>Work Order<br />Correction</h1>
-          <span>Powered by Applied Intelligence Framework</span>
+          <h1>Refab Connect</h1>
+          <span>AI-WOC</span>
         </div>
-        <div className="system-pill"><span />AI-WOC SYSTEM</div>
+        <div className="system-pill"><span />SYSTEM ACTIVE</div>
       </section>
 
       {activeView === 'Home' ? (
@@ -823,14 +823,13 @@ ${emailBody}`;
         <div className="home-active-badge">SYSTEM ACTIVE</div>
         <img className="home-system-icon" src="/refab-connect-master-1024.png" alt="Refab Connect AI-WOC" />
         <div className="hero-copy home-system-copy">
-          <h2>AI-WOC System Active</h2>
+          <h2>Correction<br />System Active</h2>
           <p>Clear. Guided. Fast.</p>
         </div>
         <button type="button" className="capture-trigger home-start-button" onClick={() => setActiveView('Capture')}>
           <span className="glass-icon-tile active">📷</span>
           <span>
             <strong>Start Capture</strong>
-            <small>Begin work order intake.</small>
           </span>
         </button>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -806,6 +806,7 @@ ${emailBody}`;
 
   return (
     <main className="shell" id="home">
+      {activeView !== 'Home' ? (
       <section className="top-card glow-card">
         <div className="brand-tile" aria-label="REFAB Connect icon">
           <img src="/apple-touch-icon.png" alt="REFAB Connect" />
@@ -816,6 +817,7 @@ ${emailBody}`;
         </div>
         <div className="system-pill"><span />SYSTEM ACTIVE</div>
       </section>
+      ) : null}
 
       {activeView === 'Home' ? (
       <>


### PR DESCRIPTION
### Motivation
- Implement the approved mobile Home screen direction so the UI matches the locked design packet and surfaces Refab Connect as the visible product identity.
- Make the Home screen feel like a dark, premium Apple-inspired mobile app with a single primary action and minimal copy.
- Ensure primary accents use blue while keeping green reserved for active/success states.

### Description
- Update the top card branding in `app/page.tsx` to display `Refab Connect` as the main title and `AI-WOC` as the supporting label, and change the top pill to read `SYSTEM ACTIVE`.
- Change the Home hero title to exactly `Correction System Active`, keep the subtext `Clear. Guided. Fast.`, and remove the extra small helper text under the `Start Capture` CTA in `app/page.tsx`.
- Preserve the four-step workflow, bottom navigation items (Home, Capture, Drafts, History, More), and the restriction against dashboards/stats/widgets in the Home layout.
- Update theme accent variables in `app/globals.css` so primary UI/action colors are blue (`--blue`, `--blue-2`, `--soft-blue`) while leaving `--green` unchanged for active/success styling.

### Testing
- Attempted `npm run lint` but it was blocked by the interactive first-time Next.js ESLint setup prompt in this non-interactive environment, so lint could not complete.
- Verified the updated strings and CSS variables by searching and inspecting `app/page.tsx` and `app/globals.css` in the workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73baf0140832388fd6d92906c2b73)