### PR TITLE
Clean up Build Correction screen UI without behavior changes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1053,59 +1053,71 @@ ${emailBody}`;
         </div>
       </section>
 
-      <section className="panel glow-card" id="issue">
+      <section className="panel glow-card build-correction-panel" id="issue">
         <div className="panel-heading">
           <p>Step 3</p>
-          <h2>State Issue</h2>
+          <h2>Build Correction</h2>
         </div>
-        <label>
-          Correction Type
-          <select value={data.correctionType} onChange={(event) => applyCorrectionType(event.target.value)}>
-            {correctionTypeOptions.map((item) => <option key={item}>{item}</option>)}
-          </select>
-        </label>
-        {data.correctionType === 'Incorrect Time / Rate' ? (
-          <>
-            <label>Current Listed Rate<input value={data.currentListedRate} onChange={(event) => setField('currentListedRate', event.target.value)} /></label>
-            <label>Correct / Observed Rate<input value={data.observedBaseline} onChange={(event) => setField('observedBaseline', event.target.value)} /></label>
-            <label>Operation / Process<select value={data.process} onChange={(event) => setField('process', event.target.value)}><option value="">Select operation / process</option>{operationProcessOptions.map((item) => <option key={item}>{item}</option>)}</select></label>
-          </>
-        ) : null}
-        {(data.correctionType === 'Missing Grind / Finish Operation' || data.correctionType === 'Missing Weld Operation') ? (
-          <>
-            <label>Correct / Observed Rate<input value={data.observedBaseline} onChange={(event) => setField('observedBaseline', event.target.value)} /></label>
-            <label>Optional note<textarea value={data.optionalNote} onChange={(event) => setField('optionalNote', event.target.value)} /></label>
-          </>
-        ) : null}
-        {data.correctionType === 'Missing Fixture / Work Instruction' ? <label>Optional note<textarea value={data.optionalNote} onChange={(event) => setField('optionalNote', event.target.value)} /></label> : null}
-        {data.correctionType === 'Wrong / Missing Router Step' ? (
-          <>
-            <label>Operation / Process<select value={data.process} onChange={(event) => setField('process', event.target.value)}><option value="">Select operation / process</option>{operationProcessOptions.map((item) => <option key={item}>{item}</option>)}</select></label>
-            <label>Optional note<textarea value={data.optionalNote} onChange={(event) => setField('optionalNote', event.target.value)} /></label>
-          </>
-        ) : null}
-        <label>
-          Category
-          <select value={data.category} onChange={(event) => setField('category', event.target.value)}>
-            <option value="">Select category</option>
-            {categoryOptions.map((item) => <option key={item}>{item}</option>)}
-          </select>
-        </label>
-        <label>
-          Priority
-          <select value={data.priority} onChange={(event) => setField('priority', event.target.value)}>
-            {priorityOptions.map((item) => <option key={item}>{item}</option>)}
-          </select>
-        </label>
-        <label>
-          Problem Summary
-          <textarea value={data.problemSummary} onChange={(event) => setField('problemSummary', event.target.value)} />
-        </label>
-        <label>
-          Requested Engineering Action
-          <textarea value={data.requestedAction} onChange={(event) => setField('requestedAction', event.target.value)} />
-        </label>
-        <button type="button" onClick={generateDraft}>Generate Report + Email Draft</button>
+        <div className="build-section">
+          <h3>Correction Type</h3>
+          <label>
+            Correction Type
+            <select value={data.correctionType} onChange={(event) => applyCorrectionType(event.target.value)}>
+              {correctionTypeOptions.map((item) => <option key={item}>{item}</option>)}
+            </select>
+          </label>
+          {data.correctionType === 'Incorrect Time / Rate' ? (
+            <>
+              <label>Current Listed Rate<input value={data.currentListedRate} onChange={(event) => setField('currentListedRate', event.target.value)} /></label>
+              <label>Correct / Observed Rate<input value={data.observedBaseline} onChange={(event) => setField('observedBaseline', event.target.value)} /></label>
+              <label>Operation / Process<select value={data.process} onChange={(event) => setField('process', event.target.value)}><option value="">Select operation / process</option>{operationProcessOptions.map((item) => <option key={item}>{item}</option>)}</select></label>
+            </>
+          ) : null}
+          {(data.correctionType === 'Missing Grind / Finish Operation' || data.correctionType === 'Missing Weld Operation') ? (
+            <>
+              <label>Correct / Observed Rate<input value={data.observedBaseline} onChange={(event) => setField('observedBaseline', event.target.value)} /></label>
+              <label>Optional note<textarea value={data.optionalNote} onChange={(event) => setField('optionalNote', event.target.value)} /></label>
+            </>
+          ) : null}
+          {data.correctionType === 'Missing Fixture / Work Instruction' ? <label>Optional note<textarea value={data.optionalNote} onChange={(event) => setField('optionalNote', event.target.value)} /></label> : null}
+          {data.correctionType === 'Wrong / Missing Router Step' ? (
+            <>
+              <label>Operation / Process<select value={data.process} onChange={(event) => setField('process', event.target.value)}><option value="">Select operation / process</option>{operationProcessOptions.map((item) => <option key={item}>{item}</option>)}</select></label>
+              <label>Optional note<textarea value={data.optionalNote} onChange={(event) => setField('optionalNote', event.target.value)} /></label>
+            </>
+          ) : null}
+        </div>
+        <div className="build-section">
+          <h3>Issue Details</h3>
+          <label>
+            Category
+            <select value={data.category} onChange={(event) => setField('category', event.target.value)}>
+              <option value="">Select category</option>
+              {categoryOptions.map((item) => <option key={item}>{item}</option>)}
+            </select>
+          </label>
+          <label>
+            Priority
+            <select value={data.priority} onChange={(event) => setField('priority', event.target.value)}>
+              {priorityOptions.map((item) => <option key={item}>{item}</option>)}
+            </select>
+          </label>
+          <label>
+            Problem Summary
+            <textarea value={data.problemSummary} onChange={(event) => setField('problemSummary', event.target.value)} />
+          </label>
+        </div>
+        <div className="build-section">
+          <h3>Requested Engineering Action</h3>
+          <label>
+            Requested Engineering Action
+            <textarea value={data.requestedAction} onChange={(event) => setField('requestedAction', event.target.value)} />
+          </label>
+        </div>
+        <div className="build-section build-section-cta">
+          <h3>Generate Draft</h3>
+          <button type="button" onClick={generateDraft}>Generate Report + Email Draft</button>
+        </div>
       </section>
       </>
       ) : null}

--- a/app/woc.css
+++ b/app/woc.css
@@ -67,3 +67,31 @@
 .capture-panel textarea {
   min-height: 145px;
 }
+
+.build-correction-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.build-section {
+  margin: 0;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(206, 213, 221, 0.24);
+  background: linear-gradient(145deg, rgba(31, 35, 42, 0.75), rgba(12, 14, 18, 0.85));
+}
+
+.build-section h3 {
+  margin: 0 0 8px;
+  color: var(--soft-blue);
+  font-size: 16px;
+  letter-spacing: 0.01em;
+}
+
+.build-section label:first-of-type {
+  margin-top: 8px;
+}
+
+.build-section-cta button {
+  margin-top: 8px;
+}


### PR DESCRIPTION
### Motivation
- Improve scanability and mobile readability of the Build Correction workflow while keeping all behavior identical. 
- Align the Build Correction screen visually with the new Home/Capture styling and reduce repeated helper text and visual clutter. 
- Preserve existing form fields, conditional correction-type behavior, report generation, and email draft/send logic.

### Description
- Reorganized the Build Correction markup in `app/page.tsx` into grouped sub-sections (`Correction Type`, `Issue Details`, `Requested Engineering Action`, `Generate Draft`) and renamed the section heading to `Build Correction` for clarity. 
- Kept every input, dropdown, conditional block, event handler, and the `generateDraft` call unchanged while only moving them into the new grouped layout. 
- Added lightweight styling in `app/woc.css` (classes: `.build-correction-panel`, `.build-section`, `.build-section-cta`) to provide consistent spacing, bordered card-like blocks, and section headers aligned with the app's visual language. 
- No logic changes to report generation, email draft creation, send gating, OCR/extraction, or data model fields.

### Testing
- `npm run build` completed successfully and the production build was generated without errors. 
- `npm run lint` in this environment triggered the Next.js ESLint first-time interactive setup prompt and did not complete a non-interactive lint run (no lint rules were changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74d704ab48323a0a66520f1289af9)