### PR TITLE
Clean up Drafts screen UI grouping for mobile review

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1130,35 +1130,54 @@ ${emailBody}`;
         </div>
         {showDraft ? (
           <>
-            <div className={readyToDraft ? 'gate good' : 'gate warn'}>
-              {readyToDraft ? 'Required fields complete. Confirm accuracy before sending.' : 'Some required fields are missing. Fill bracketed required items before confirming.'}
-            </div>
-            {readinessWarnings.length ? (
-              <div className="gate warn">
-                <strong>Warnings (do not block send if required fields are complete):</strong>
-                <ul>
-                  {readinessWarnings.map((warning) => <li key={warning}>{warning}</li>)}
-                </ul>
+            <section className="draft-group">
+              <h3 className="draft-group-title">Readiness + Warnings</h3>
+              <div className={readyToDraft ? 'gate good' : 'gate warn'}>
+                {readyToDraft ? 'Required fields complete. Confirm accuracy before sending.' : 'Some required fields are missing. Fill bracketed required items before confirming.'}
               </div>
-            ) : null}
-            <h3>Correction Report</h3>
-            <pre>{report}</pre>
-            <h3>Email Draft</h3>
-            <pre>{emailDraft}</pre>
-            {confirmationLabels.map((label, index) => (
-              <label className="check" key={label}>
-                <input type="checkbox" checked={checks[index]} onChange={(event) => setChecks((current) => current.map((value, i) => i === index ? event.target.checked : value))} />
-                {label}
-              </label>
-            ))}
-        <div className="button-row">
-              <button type="button" className="secondary" onClick={() => copyText(report)}>Copy Report</button>
-              <button type="button" className="secondary" onClick={() => copyText(emailDraft)}>Copy Email</button>
-            </div>
-            <button type="button" disabled={!readyToDraft || !allConfirmed || sending} onClick={sendEmail}>{sending ? 'Sending...' : 'Send Email'}</button>
-            <div className="button-row">
-              <button type="button" className="secondary" onClick={clearForm}>Start New Correction / Clear Form</button>
-            </div>
+              {readinessWarnings.length ? (
+                <div className="gate warn">
+                  <strong>Warnings (do not block send if required fields are complete):</strong>
+                  <ul>
+                    {readinessWarnings.map((warning) => <li key={warning}>{warning}</li>)}
+                  </ul>
+                </div>
+              ) : null}
+            </section>
+
+            <section className="draft-group">
+              <h3 className="draft-group-title">Report Preview</h3>
+              <pre>{report}</pre>
+            </section>
+
+            <section className="draft-group">
+              <h3 className="draft-group-title">Email Preview</h3>
+              <pre>{emailDraft}</pre>
+            </section>
+
+            <section className="draft-group">
+              <h3 className="draft-group-title">Confirmation Checks</h3>
+              <div className="checks-stack">
+                {confirmationLabels.map((label, index) => (
+                  <label className="check" key={label}>
+                    <input type="checkbox" checked={checks[index]} onChange={(event) => setChecks((current) => current.map((value, i) => i === index ? event.target.checked : value))} />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            <section className="draft-group">
+              <h3 className="draft-group-title">Copy + Send Actions</h3>
+              <div className="button-row">
+                <button type="button" className="secondary" onClick={() => copyText(report)}>Copy Report</button>
+                <button type="button" className="secondary" onClick={() => copyText(emailDraft)}>Copy Email</button>
+              </div>
+              <button type="button" disabled={!readyToDraft || !allConfirmed || sending} onClick={sendEmail}>{sending ? 'Sending...' : 'Send Email'}</button>
+              <div className="button-row">
+                <button type="button" className="secondary" onClick={clearForm}>Start New Correction / Clear Form</button>
+              </div>
+            </section>
           </>
         ) : (
           <div className="empty-state">

--- a/app/woc.css
+++ b/app/woc.css
@@ -95,3 +95,47 @@
 .build-section-cta button {
   margin-top: 8px;
 }
+
+.draft-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.draft-group {
+  margin: 0;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(206, 213, 221, 0.24);
+  background: linear-gradient(145deg, rgba(31, 35, 42, 0.75), rgba(12, 14, 18, 0.85));
+}
+
+.draft-group-title {
+  margin: 0 0 10px;
+  color: var(--soft-blue);
+  font-size: 16px;
+  letter-spacing: 0.01em;
+}
+
+.checks-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.gate ul {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+@media (max-width: 620px) {
+  .draft-group {
+    padding: 12px;
+  }
+
+  .draft-group-title {
+    font-size: 15px;
+  }
+
+  .button-row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve mobile and tablet readability of the Drafts / Confirm + Send view by reducing the wall-of-text layout and making visual groups easier to scan. 
- Preserve all existing preview content, copy actions, confirmation checks, and send gating while only changing presentation and spacing.

### Description
- Reorganized the Drafts view into clear, labeled sections: `Readiness + Warnings`, `Report Preview`, `Email Preview`, `Confirmation Checks`, and `Copy + Send Actions` by updating `app/page.tsx` to wrap content in semantic section blocks. 
- Added CSS for the new layout cards and responsive spacing including `.draft-panel`, `.draft-group`, `.draft-group-title`, `.checks-stack`, and a small-screen rule to stack action buttons in `app/woc.css`.
- Kept all existing handlers and logic unchanged, including the checkbox state mapping and the `Send Email` disabling condition (`!readyToDraft || !allConfirmed || sending`).
- Files changed: `app/page.tsx`, `app/woc.css`.

### Testing
- Ran `npm run lint`, which could not complete non-interactively due to Next.js ESLint initialization prompting for configuration, so lint did not finish in this environment (interactive prompt). 
- No other automated tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7509e443c832395b5e6cc9342b327)