### PR TITLE
Clean up History and More screen UI styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1191,33 +1191,46 @@ ${emailBody}`;
       ) : null}
 
       {activeView === 'History' ? (
-      <section className="panel glow-card compact-info" id="history">
+      <section className="panel glow-card compact-info history-panel" id="history">
         <div className="panel-heading">
           <p>History</p>
           <h2>Submission History</h2>
         </div>
+        <p className="history-intro">Recent Engineering submissions are listed below with the same send-time details captured at draft confirmation.</p>
         {history.length ? (
           <ul className="history-list">
             {history.map((item) => (
               <li key={item.wocId}>
-                <strong>{item.wocId}</strong> — {item.dateSubmitted} — WO {item.workOrderNumber || 'TBD'} / {item.partNumber || 'TBD'} — {item.category} — {item.status}
+                <strong>{item.wocId}</strong>
+                <span>{item.dateSubmitted}</span>
+                <span>WO {item.workOrderNumber || 'TBD'} / {item.partNumber || 'TBD'}</span>
+                <span>{item.category} • {item.status}</span>
               </li>
             ))}
           </ul>
         ) : (
-          <p>Sent requests will appear here after email delivery is connected and tracking is added.</p>
+          <div className="empty-state history-empty-state">
+            <strong>No submissions yet.</strong>
+            <p>Sent requests will appear here after email delivery is connected and tracking is added.</p>
+          </div>
         )}
       </section>
       ) : null}
 
       {activeView === 'More' ? (
-      <section className="panel glow-card compact-info" id="more">
+      <section className="panel glow-card compact-info more-panel" id="more">
         <div className="panel-heading">
           <p>System</p>
           <h2>REFAB Connect</h2>
         </div>
-        <p>Work Order Correction powered by Applied Intelligence Framework. Draft first. Confirm accuracy. Then send.</p>
-        <p className="mini-note">Default Engineering recipient: {DEFAULT_TO_EMAIL}</p>
+        <section className="more-group">
+          <h3 className="more-group-title">AI-WOC Scope</h3>
+          <p>Work Order Correction powered by Applied Intelligence Framework. Draft first. Confirm accuracy. Then send.</p>
+        </section>
+        <section className="more-group">
+          <h3 className="more-group-title">Default Recipient</h3>
+          <p className="mini-note">Default Engineering recipient: {DEFAULT_TO_EMAIL}</p>
+        </section>
       </section>
       ) : null}
 

--- a/app/woc.css
+++ b/app/woc.css
@@ -52,16 +52,63 @@
   margin: 12px 0 0;
   padding: 0;
   list-style: none;
+  display: grid;
+  gap: 10px;
 }
 
 .history-list li {
-  margin-top: 10px;
-  padding: 12px;
+  margin-top: 0;
+  padding: 13px 14px;
   border-radius: 14px;
   border: 1px solid rgba(206, 213, 221, 0.24);
-  background: rgba(13, 16, 21, 0.78);
+  background: linear-gradient(145deg, rgba(31, 35, 42, 0.75), rgba(12, 14, 18, 0.85));
   color: var(--muted);
   font-weight: 750;
+  display: grid;
+  gap: 6px;
+}
+
+.history-list li strong {
+  color: var(--soft-blue);
+}
+
+.history-list li span {
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.history-intro {
+  margin: 0;
+}
+
+.history-empty-state {
+  margin-top: 12px;
+  text-align: left;
+}
+
+.history-panel,
+.more-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.more-group {
+  margin: 0;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(206, 213, 221, 0.24);
+  background: linear-gradient(145deg, rgba(31, 35, 42, 0.75), rgba(12, 14, 18, 0.85));
+}
+
+.more-group-title {
+  margin: 0 0 8px;
+  color: var(--soft-blue);
+  font-size: 16px;
+  letter-spacing: 0.01em;
+}
+
+.more-group p {
+  margin: 0;
 }
 
 .capture-panel textarea {


### PR DESCRIPTION
### Motivation
- Bring the History and More/System screens into visual alignment with the recently cleaned Home, Capture, Build Correction, and Drafts screens by improving grouping, spacing, and card styling.
- Improve History scanability and empty-state readability while preserving all existing data, send logic, and default recipient behaviour.

### Description
- Updated `app/page.tsx` to add `history-panel` and `more-panel` classes, insert a `history-intro` line, refactor each history row into stacked `<span>` detail lines, and replace the simple message with an intentional empty-state block for History. 
- Reworked the More/System content in `app/page.tsx` into two grouped cards (`more-group`) titled "AI-WOC Scope" and "Default Recipient" while keeping `DEFAULT_TO_EMAIL` unchanged. 
- Added UI-only CSS in `app/woc.css` to style `.history-list`, `.history-list li`, `.history-intro`, `.history-empty-state`, `.history-panel`, `.more-panel`, `.more-group`, and related typography to match existing card/section visuals. 
- No functional changes were made to history data loading, draft generation, send behavior, extraction/reporting logic, or application settings.

### Testing
- Attempted to run `npm run lint`, but Next.js prompted for initial ESLint configuration interactively so the lint pass could not complete non-interactively in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7533f875c83239f45a7d31d3c2674)