### PR TITLE
Refine iPad home layout centering and balance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -752,31 +752,39 @@ pre {
 
 @media (min-width: 768px) and (max-width: 1100px) {
   #home {
-    max-width: 900px;
-    padding-left: 24px;
-    padding-right: 24px;
+    max-width: 980px;
+    padding-left: 28px;
+    padding-right: 28px;
+    min-height: calc(100dvh - 132px);
+    align-content: start;
   }
 
   #home .top-card,
   #home .home-system-hero,
   #home .home-workflow {
-    width: min(100%, 680px);
+    width: min(100%, 740px);
     margin-left: auto;
     margin-right: auto;
   }
 
   #home .home-system-hero {
-    padding: 28px 30px;
+    min-height: clamp(460px, 60vh, 560px);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 34px 34px 30px;
+    margin-top: clamp(12px, 4vh, 36px);
   }
 
   #home .home-workflow {
-    padding: 20px 22px;
+    padding: 22px 24px 14px;
+    margin-top: 18px;
   }
 
   .bottom-nav {
-    max-width: 640px;
-    left: max(24px, calc((100vw - 640px) / 2));
-    right: max(24px, calc((100vw - 640px) / 2));
+    max-width: 700px;
+    left: max(24px, calc((100vw - 700px) / 2));
+    right: max(24px, calc((100vw - 700px) / 2));
   }
 }
 


### PR DESCRIPTION
### Motivation
- Improve the iPad/tablet Home screen composition so the content column is visually centered and the hero feels vertically anchored while preserving phone behavior and all existing elements and logic.
- Avoid full-width stretching on tablet and ensure the bottom navigation stays centered relative to the content column.

### Description
- Bumped tablet container bounds in the `768px–1100px` media query by setting `#home` `max-width: 980px`, increased side padding, and added `min-height: calc(100dvh - 132px)` with `align-content: start` to stabilize vertical composition.
- Increased the centered content column cap for `.top-card`, `.home-system-hero`, and `.home-workflow` to `width: min(100%, 740px)` so the Home column feels balanced on tablets.
- Rebalanced the hero by adding `min-height: clamp(460px, 60vh, 560px)`, converting the hero to a vertical flex container (`display: flex; flex-direction: column; justify-content: center`) and adjusting padding/margin to visually center icon + title + button.
- Tuned workflow spacing and padding (`padding: 22px 24px 14px` and `margin-top: 18px`) and widened/recen tered the bottom nav (`max-width: 700px`) for consistent alignment under the hero.

### Testing
- Ran the repository checks available in this environment and verified the CSS patch applied cleanly with no syntax errors observed in the edited file.
- Attempted `npm run -s lint` but it could not complete non-interactively because Next.js prompted for initial ESLint configuration in this environment, so linting was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7553f80a883238670da312bf0183f)