### PR TITLE
Premium polish pass for iPad Home screen

### DIFF
--- a/app/ipad-home-layout.css
+++ b/app/ipad-home-layout.css
@@ -21,10 +21,10 @@
   }
 
   #home .home-layout-column {
-    width: min(100%, 560px);
+    width: min(100%, 540px);
     margin-inline: auto;
     display: grid;
-    gap: 18px;
+    gap: 12px;
   }
 
   #home .home-system-hero,
@@ -36,6 +36,56 @@
 
   #home .home-system-hero {
     margin-top: 0;
+    padding: 26px 24px 20px;
+  }
+
+  #home .home-system-icon {
+    width: clamp(150px, 27vw, 198px);
+  }
+
+  #home .home-system-copy h2 {
+    font-size: clamp(32px, 4.5vw, 42px);
+  }
+
+  #home .home-system-copy p {
+    margin-top: 10px;
+    font-size: clamp(16px, 2.1vw, 20px);
+    letter-spacing: 0.03em;
+  }
+
+  #home .home-start-button {
+    width: min(390px, 100%);
+    min-height: 72px;
+    margin-top: 0;
+  }
+
+  #home .home-start-button .glass-icon-tile {
+    width: 50px;
+    height: 50px;
+  }
+
+  #home .home-workflow {
+    margin-top: 4px;
+    padding: 12px 14px 8px;
+  }
+
+  #home .home-workflow-row {
+    padding: 8px 10px;
+  }
+
+  #home .home-workflow-row .step-box {
+    width: 46px;
+    height: 46px;
+    border-radius: 14px;
+    font-size: 22px;
+  }
+
+  #home .home-workflow-row h3 {
+    font-size: 17px;
+  }
+
+  #home .home-workflow-row p {
+    font-size: 13px;
   }
 
   .bottom-nav {


### PR DESCRIPTION
### Motivation
- Make the iPad Home screen feel more premium and balanced by tightening visual rhythm between the hero and workflow areas.  
- Keep the hero as the primary visual anchor while reducing an oversized appearance so it feels intentional.  
- Preserve the Start Capture CTA prominence while making the workflow read as secondary guidance.

### Description
- Adjusted tablet composition by reducing the home column width and vertical gap (`560px` -> `540px`, `gap: 18px` -> `12px`) in `app/ipad-home-layout.css`.  
- Tuned hero card spacing and scale by adding padding to the hero, constraining the system icon size, and reducing heading and supporting copy sizes.  
- Reduced the visual footprint of the primary CTA by narrowing the `Start Capture` width, lowering `min-height`, and resizing the button icon tile.  
- De-emphasized the workflow area by tightening its margin/padding and scaling down step box size and step typography for a calmer secondary presentation.

### Testing
- Attempted to run lint with `npm run lint`, but the Next.js ESLint setup prompted interactively so the command could not complete non-interactively.  
- No other automated test runs were executed against the change in this environment, so validation remains visual/manual in a tablet viewport (`min-width: 768px` and `max-width: 1400px`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f760e9147c8323adb5335c1ab329f1)